### PR TITLE
fix: use the right regexp validation on alert rule name

### DIFF
--- a/mimir/resource_mimir_rule_group_alerting.go
+++ b/mimir/resource_mimir_rule_group_alerting.go
@@ -259,9 +259,9 @@ func flattenAlertingRules(v []alertingRule) []map[string]interface{} {
 func validateAlertingRuleName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
-	if !labelNameRegexp.MatchString(value) {
+	if !groupRuleNameRegexp.MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"\"%s\": Invalid Alerting Rule Name %q. Must match the regex %s", k, value, labelNameRegexp))
+			"\"%s\": Invalid Alerting Rule Name %q. Must match the regex %s", k, value, groupRuleNameRegexp))
 	}
 
 	return


### PR DESCRIPTION
The characters `-` and `.` are allowed in the alert rule names, but the provider currently doesn't support it since it's used the label regexp validation rule (`labelNameRegexp`). Using the `groupRuleNameRegexp` will allow the right validation of the alert rule name.

```sh
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: "rule.0.alert": Invalid Alerting Rule Name "observability-cpu_percent". Must match the regex ^[a-zA-Z_][a-zA-Z0-9_]*$
│
│   with module.alerts.mimir_rule_group_alerting.this,
│   on .terraform/modules/alerts/rule_group_alerting.tf line 36, in resource "mimir_rule_group_alerting" "this":
│   36: resource "mimir_rule_group_alerting" "this" {
│
╵
╷
│ Error: "rule.0.alert": Invalid Alerting Rule Name "observability-cpu_percent". Must match the regex ^[a-zA-Z_][a-zA-Z0-9_]*$
│
│   with module.alerts_stg.mimir_rule_group_alerting.this,
│   on .terraform/modules/alerts_stg/rule_group_alerting.tf line 36, in resource "mimir_rule_group_alerting" "this":
│   36: resource "mimir_rule_group_alerting" "this" {
│
╵
```