### PR TITLE
Break out the `/config` prefix so this provider can configure Loki rules too

### DIFF
--- a/mimir/api_client.go
+++ b/mimir/api_client.go
@@ -20,6 +20,7 @@ type apiClientOpt struct {
 	uri             string
 	rulerURI        string
 	alertmanagerURI string
+	configPrefix    string
 	cert            string
 	key             string
 	ca              string
@@ -37,6 +38,7 @@ type apiClient struct {
 	uri             string
 	rulerURI        string
 	alertmanagerURI string
+	configPrefix    string
 	insecure        bool
 	token           string
 	username        string
@@ -106,6 +108,7 @@ func NewAPIClient(opt *apiClientOpt) (*apiClient, error) {
 		uri:             opt.uri,
 		rulerURI:        opt.rulerURI,
 		alertmanagerURI: opt.alertmanagerURI,
+		configPrefix:    opt.configPrefix,
 		insecure:        opt.insecure,
 		token:           opt.token,
 		username:        opt.username,

--- a/mimir/provider.go
+++ b/mimir/provider.go
@@ -105,6 +105,12 @@ func Provider(version string) func() *schema.Provider {
 					DefaultFunc: schema.EnvDefaultFunc("MIMIR_FORMAT_PROMQL_EXPR", false),
 					Description: "Enable the formatting of PromQL expression.",
 				},
+				"config_prefix": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "/config",
+					Description: "The path on top of the ruler uri used to access the config.",
+				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"mimir_alertmanager_config":  dataSourcemimirAlertmanagerConfig(),
@@ -145,6 +151,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		uri:             d.Get("uri").(string),
 		rulerURI:        d.Get("ruler_uri").(string),
 		alertmanagerURI: d.Get("alertmanager_uri").(string),
+		configPrefix:    d.Get("config_prefix").(string),
 		headers:         headers,
 		timeout:         d.Get("timeout").(int),
 		debug:           d.Get("debug").(bool),

--- a/mimir/resource_mimir_rule_group_alerting.go
+++ b/mimir/resource_mimir_rule_group_alerting.go
@@ -106,7 +106,7 @@ func resourcemimirRuleGroupAlertingCreate(ctx context.Context, d *schema.Resourc
 	data, _ := yaml.Marshal(rules)
 	headers := map[string]string{"Content-Type": "application/yaml"}
 
-	path := fmt.Sprintf("/config/v1/rules/%s", namespace)
+	path := fmt.Sprintf("%s/v1/rules/%s", client.configPrefix, namespace)
 	_, err := client.sendRequest("ruler", "POST", path, string(data), headers)
 	baseMsg := fmt.Sprintf("Cannot create alerting rule group '%s' -", name)
 	err = handleHTTPError(err, baseMsg)
@@ -126,7 +126,7 @@ func resourcemimirRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceD
 	name := idArr[1]
 
 	var headers map[string]string
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	path := fmt.Sprintf("%s/v1/rules/%s/%s", client.configPrefix, namespace, name)
 	jobraw, err := client.sendRequest("ruler", "GET", path, "", headers)
 
 	baseMsg := fmt.Sprintf("Cannot read alerting rule group '%s' -", name)
@@ -179,7 +179,7 @@ func resourcemimirRuleGroupAlertingUpdate(ctx context.Context, d *schema.Resourc
 		data, _ := yaml.Marshal(rules)
 		headers := map[string]string{"Content-Type": "application/yaml"}
 
-		path := fmt.Sprintf("/config/v1/rules/%s", namespace)
+		path := fmt.Sprintf("%s/v1/rules/%s", client.configPrefix, namespace)
 		_, err := client.sendRequest("ruler", "POST", path, string(data), headers)
 		baseMsg := fmt.Sprintf("Cannot update alerting rule group '%s' -", name)
 
@@ -196,7 +196,7 @@ func resourcemimirRuleGroupAlertingDelete(ctx context.Context, d *schema.Resourc
 	name := d.Get("name").(string)
 	namespace := d.Get("namespace").(string)
 	var headers map[string]string
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	path := fmt.Sprintf("%s/v1/rules/%s/%s", client.configPrefix, namespace, name)
 	_, err := client.sendRequest("ruler", "DELETE", path, "", headers)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(

--- a/mimir/resource_mimir_rule_group_recording.go
+++ b/mimir/resource_mimir_rule_group_recording.go
@@ -85,7 +85,7 @@ func resourcemimirRuleGroupRecordingCreate(ctx context.Context, d *schema.Resour
 	data, _ := yaml.Marshal(rules)
 	headers := map[string]string{"Content-Type": "application/yaml"}
 
-	path := fmt.Sprintf("/config/v1/rules/%s", namespace)
+	path := fmt.Sprintf("%s/v1/rules/%s", client.configPrefix, namespace)
 	_, err := client.sendRequest("ruler", "POST", path, string(data), headers)
 	baseMsg := fmt.Sprintf("Cannot create recording rule group '%s' -", name)
 	err = handleHTTPError(err, baseMsg)
@@ -105,7 +105,7 @@ func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resource
 	name := idArr[1]
 
 	var headers map[string]string
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	path := fmt.Sprintf("%s/v1/rules/%s/%s", client.configPrefix, namespace, name)
 	jobraw, err := client.sendRequest("ruler", "GET", path, "", headers)
 
 	baseMsg := fmt.Sprintf("Cannot read recording rule group '%s' -", name)
@@ -158,7 +158,7 @@ func resourcemimirRuleGroupRecordingUpdate(ctx context.Context, d *schema.Resour
 		data, _ := yaml.Marshal(rules)
 		headers := map[string]string{"Content-Type": "application/yaml"}
 
-		path := fmt.Sprintf("/config/v1/rules/%s", namespace)
+		path := fmt.Sprintf("%s/v1/rules/%s", client.configPrefix, namespace)
 		_, err := client.sendRequest("ruler", "POST", path, string(data), headers)
 		baseMsg := fmt.Sprintf("Cannot update recording rule group '%s' -", name)
 		err = handleHTTPError(err, baseMsg)
@@ -174,7 +174,7 @@ func resourcemimirRuleGroupRecordingDelete(ctx context.Context, d *schema.Resour
 	name := d.Get("name").(string)
 	namespace := d.Get("namespace").(string)
 	var headers map[string]string
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	path := fmt.Sprintf("%s/v1/rules/%s/%s", client.configPrefix, namespace, name)
 	_, err := client.sendRequest("ruler", "DELETE", path, "", headers)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(


### PR DESCRIPTION
[Loki has a prometheus compatible ruler API](https://grafana.com/docs/loki/latest/api/). However, where as Mimir prefixes all of it's ruler requests with `/config`, Loki does no such thing, meaning this provider cannot be used to configure Loki rules without proxying the Loki instance. This PR pulls out the config prefix into a configuration variable, keeping the default behavior exactly as is but allowing the prefix to be cleared to allow the configuration of Loki instances.

I have tested this manually and verified it does work as expected and all existing tests pass but I'm not sure how y'all would like this to be tested. Feel free to let me know and I can add something in if needed.