### PR TITLE
fix: rule group not found after creation

### DIFF
--- a/mimir/resource_mimir_rule_group_alerting_test.go
+++ b/mimir/resource_mimir_rule_group_alerting_test.go
@@ -134,6 +134,8 @@ func TestAccResourceRuleGroupAlerting_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1", "namespace", "namespace_1"),
 					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1", "rule.0.alert", "test1"),
 					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1", "rule.0.expr", "test1_metric"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1", "rule.1.alert", "test2"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1", "rule.1.expr", "test2_metric"),
 				),
 			},
 			{
@@ -152,11 +154,27 @@ func TestAccResourceRuleGroupAlerting_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1", "rule.1.annotations.description", "test 2 alert description"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccResourceRuleGroupAlerting_Federated(t *testing.T) {
+	// Init client
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceRuleGroupAlerting_federated_rule_group,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.alert_1_federated_rule_group", "alert_1", client),
-					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "name", "alert_1"),
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.alert_1_federated_rule_group", "alert_1_federated_rule_group", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "name", "alert_1_federated_rule_group"),
 					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "namespace", "namespace_1"),
 					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "source_tenants.0", "tenant-a"),
 					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "source_tenants.1", "tenant-b"),
@@ -203,6 +221,10 @@ const testAccResourceRuleGroupAlerting_basic = `
 			alert = "test1"
 			expr  = "test1_metric"
 		}
+		rule {
+			alert = "test2"
+			expr   = "test2_metric"
+		}
 	}
 `
 
@@ -242,7 +264,7 @@ const testAccResourceRuleGroupAlerting_prettify_promql_expr = `
 
 const testAccResourceRuleGroupAlerting_federated_rule_group = `
 	resource "mimir_rule_group_alerting" "alert_1_federated_rule_group" {
-		name = "alert_1"
+		name = "alert_1_federated_rule_group"
 		source_tenants = ["tenant-a", "tenant-b"]
 		namespace = "namespace_1"
 		rule {

--- a/mimir/resource_mimir_rule_group_recording.go
+++ b/mimir/resource_mimir_rule_group_recording.go
@@ -3,7 +3,9 @@ package mimir
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -100,10 +102,23 @@ func resourcemimirRuleGroupRecordingCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	d.SetId(fmt.Sprintf("%s/%s", namespace, name))
+
+	// Retry read as mimir api could return a 404 status code.
+	// Add delay of 1s between each retry with a 3 max retries.
+	for i := 1; i < 4; i++ {
+		result := resourcemimirRuleGroupRecordingRead(ctx, d, meta)
+		if len(result) > 0 && !result.HasError() {
+			log.Printf("[WARN] Recording rule group previously created'%s' not found (%d/3)", name, i)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		return result
+	}
 	return resourcemimirRuleGroupRecordingRead(ctx, d, meta)
 }
 
 func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	client := meta.(*apiClient)
 
 	// use id as read is also called by import
@@ -118,9 +133,19 @@ func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resource
 	baseMsg := fmt.Sprintf("Cannot read recording rule group '%s' -", name)
 	err = handleHTTPError(err, baseMsg)
 	if err != nil {
-		if strings.Contains(err.Error(), "response code '404'") {
+		if d.IsNewResource() && strings.Contains(err.Error(), "response code '404'") {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Recording rule group '%s' not found", name),
+			})
+			return diags
+		} else if !d.IsNewResource() && strings.Contains(err.Error(), "response code '404'") {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Recording rule group '%s' (id: %s) not found, removing from state", name, d.Id()),
+			})
 			d.SetId("")
-			return diag.Diagnostics{}
+			return diags
 		}
 		return diag.FromErr(err)
 	}
@@ -151,8 +176,7 @@ func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resource
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	return diag.Diagnostics{}
+	return diags
 }
 
 func resourcemimirRuleGroupRecordingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/mimir/resource_mimir_rule_group_recording_test.go
+++ b/mimir/resource_mimir_rule_group_recording_test.go
@@ -113,26 +113,42 @@ func TestAccResourceRuleGroupRecording_Basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccResourceRuleGroupRecording_interval,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_interval", "record_1_interval", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "name", "record_1_interval"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "rule.0.record", "test1_info"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "rule.0.expr", "test1_metric"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "interval", "6h"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceRuleGroupRecording_Federated(t *testing.T) {
+	// Init client
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
 				Config: testAccResourceRuleGroupRecording_federated_rule_group,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_federated_rule_group", "record_1", client),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "name", "record_1"),
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_federated_rule_group", "record_1_federated_rule_group", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "name", "record_1_federated_rule_group"),
 					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "namespace", "namespace_1"),
 					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "source_tenants.0", "tenant-a"),
 					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "source_tenants.1", "tenant-b"),
 					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "rule.0.record", "test1_info"),
 					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "rule.0.expr", "test1_metric"),
-				),
-			},
-			{
-				Config: testAccResourceRuleGroupRecording_interval,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_interval", "record_1", client),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "name", "record_1"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "namespace", "namespace_1"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "rule.0.record", "test1_info"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "rule.0.expr", "test1_metric"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "interval", "6h"),
 				),
 			},
 		},
@@ -170,7 +186,7 @@ const testAccResourceRuleGroupRecording_basic_update = `
 
 const testAccResourceRuleGroupRecording_federated_rule_group = `
 	resource "mimir_rule_group_recording" "record_1_federated_rule_group" {
-		name = "record_1"
+		name = "record_1_federated_rule_group"
 		namespace = "namespace_1"
 		source_tenants = ["tenant-a", "tenant-b"]
 		rule {
@@ -181,13 +197,13 @@ const testAccResourceRuleGroupRecording_federated_rule_group = `
 `
 
 const testAccResourceRuleGroupRecording_interval = `
-        resource "mimir_rule_group_recording" "record_1_interval" {
-                name = "record_1"
-                namespace = "namespace_1"
-                interval = "6h"
-                rule {
-                        record = "test1_info"
-                        expr   = "test1_metric"
-                }
-        }
+    resource "mimir_rule_group_recording" "record_1_interval" {
+            name = "record_1_interval"
+            namespace = "namespace_1"
+            interval = "6h"
+            rule {
+                    record = "test1_info"
+                    expr   = "test1_metric"
+            }
+    }
 `


### PR DESCRIPTION
When there is many changes on mimir ruler api in the same time, the ruler api could return a 404 just after a rule group creation. That is why we could get this error:

```
Error: Provider produced inconsistent result after apply
        
        When applying changes to
        mimir_rule_group_recording.record_1_federated_rule_group, provider
        "registry.terraform.io/-/mimir" produced an unexpected new value for was
        present, but now absent.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
```
That means that the rule group have been created but the read function didn't find it (mimir ruler api latency between create/read ??), and with 404 error in read function the rule group is removed from the state.

To prevent this error, I add a retry step in create function with a delay on 1s between each retry to read the rule group. If the max retry (set to 3) is exceeded, it make a last read and fail if another 404 occurs.