### PR TITLE
feat: prevent overwriting remote config if not TF managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ resource "mimir_rule_group_alerting" "test" {
   namespace = "namespace1"
   rule {
     alert       = "HighRequestLatency"
-    expr        = "job:request_latency_seconds:mean5m{job="myjob"} > 0.5"
+    expr        = "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5"
     for         = "10m"
     labels      = {
       severity = "warning"

--- a/docs/data-sources/rule_group_recording.md
+++ b/docs/data-sources/rule_group_recording.md
@@ -33,7 +33,7 @@ data "mimir_rule_group_recording" "record" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `interval` (String) Recording Rule group interval.
+- `interval` (String) Recording Rule group interval
 - `rule` (List of Object) (see [below for nested schema](#nestedatt--rule))
 - `source_tenants` (List of String) Allows aggregating data from multiple tenants while evaluating a rule group.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,13 +68,15 @@ provider "mimir" {
 ### Optional
 
 - `alertmanager_uri` (String) mimir alertmanager base url
-- `ca` (String) Client ca for client authentication
-- `cert` (String) Client cert for client authentication
+- `ca` (String) Client ca (filepath or inline) for client authentication
+- `cert` (String) Client cert (filepath or inline) for client authentication
 - `debug` (Boolean) Enable debug mode to trace requests executed.
 - `format_promql_expr` (Boolean) Enable the formatting of PromQL expression.
 - `headers` (Map of String) A map of header names and values to set on all outbound requests.
 - `insecure` (Boolean) When using https, this disables TLS verification of the host.
-- `key` (String) Client key for client authentication
+- `key` (String) Client key (filepath or inline) for client authentication
+- `overwrite_alertmanager_config` (Boolean) Overwrite the current alertmanager config on create.
+- `overwrite_rule_group_config` (Boolean) Overwrite the current rule group (alerting/recording) config on create.
 - `password` (String) When set, will use this password for BASIC auth to the API.
 - `proxy_url` (String) URL to the proxy to be used for all API requests
 - `ruler_uri` (String) mimir ruler base url

--- a/docs/resources/rule_group_alerting.md
+++ b/docs/resources/rule_group_alerting.md
@@ -18,7 +18,7 @@ resource "mimir_rule_group_alerting" "test" {
   namespace = "namespace1"
   rule {
     alert       = "HighRequestLatency"
-    expr        = "job:request_latency_seconds:mean5m{job="myjob"} > 0.5"
+    expr        = "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5"
     for         = "10m"
     labels      = {
       severity = "warning"

--- a/examples/resources/mimir_rule_group_alerting/resource.tf
+++ b/examples/resources/mimir_rule_group_alerting/resource.tf
@@ -3,7 +3,7 @@ resource "mimir_rule_group_alerting" "test" {
   namespace = "namespace1"
   rule {
     alert       = "HighRequestLatency"
-    expr        = "job:request_latency_seconds:mean5m{job="myjob"} > 0.5"
+    expr        = "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5"
     for         = "10m"
     labels      = {
       severity = "warning"

--- a/examples/resources/mimir_rule_group_recording/resource.tf
+++ b/examples/resources/mimir_rule_group_recording/resource.tf
@@ -1,6 +1,7 @@
 resource "mimir_rule_group_recording" "test" {
   name      = "test1"
   namespace = "namespace1"
+  interval  = "6h"
   rule {
     expr   = "sum by (job) (http_inprogress_requests)"
     record = "job:http_inprogress_requests:sum"

--- a/mimir/provider.go
+++ b/mimir/provider.go
@@ -9,8 +9,10 @@ import (
 )
 
 var (
-	apiAlertsPath          = "/api/v1/alerts"
-	enablePromQLExprFormat bool
+	apiAlertsPath               = "/api/v1/alerts"
+	enablePromQLExprFormat      bool
+	overwriteAlertmanagerConfig bool
+	overwriteRuleGroupConfig    bool
 )
 
 func Provider(version string) func() *schema.Provider {
@@ -75,17 +77,17 @@ func Provider(version string) func() *schema.Provider {
 				"cert": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					Description: "Client cert for client authentication",
+					Description: "Client cert (filepath or inline) for client authentication",
 				},
 				"key": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					Description: "Client key for client authentication",
+					Description: "Client key (filepath or inline) for client authentication",
 				},
 				"ca": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					Description: "Client ca for client authentication",
+					Description: "Client ca (filepath or inline) for client authentication",
 				},
 				"headers": {
 					Type:        schema.TypeMap,
@@ -110,6 +112,18 @@ func Provider(version string) func() *schema.Provider {
 					Optional:    true,
 					DefaultFunc: schema.EnvDefaultFunc("MIMIR_FORMAT_PROMQL_EXPR", false),
 					Description: "Enable the formatting of PromQL expression.",
+				},
+				"overwrite_alertmanager_config": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("MIMIR_OVERWRITE_ALERTMANAGER_CONFIG", false),
+					Description: "Overwrite the current alertmanager config on create.",
+				},
+				"overwrite_rule_group_config": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("MIMIR_OVERWRITE_RULE_GROUP_CONFIG", false),
+					Description: "Overwrite the current rule group (alerting/recording) config on create.",
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
@@ -158,6 +172,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	}
 
 	enablePromQLExprFormat = d.Get("format_promql_expr").(bool)
+	overwriteAlertmanagerConfig = d.Get("overwrite_alertmanager_config").(bool)
+	overwriteRuleGroupConfig = d.Get("overwrite_rule_group_config").(bool)
 
 	client, err := NewAPIClient(opt)
 	return client, diag.FromErr(err)


### PR DESCRIPTION
Add 2 provider parameters:
-  `overwrite_alertmanager_config` (default: **false**) 
- `overwrite_rule_group_config` (default: **false**) 


 This prevent to overwrite remote config in case of resources not managed by TF (not in tf state).

Example: 
```

│ Error: alertmanager config already exists
│ 
│   with mimir_alertmanager_config.config,
│   on main.tf line 20, in resource "mimir_alertmanager_config" "config":
│   20: resource "mimir_alertmanager_config" "config" {


│ Error: alerting rule group 'testfgx3' (namespace: testfgx) already exists
│ 
│   with module.mimir_alerting_rule3.mimir_rule_group_alerting.alert,
│   on modules/mimir_alerting_rule/main.tf line 30, in resource "mimir_rule_group_alerting" "alert":
│   30: resource "mimir_rule_group_alerting" "alert" {
│ 


│ Error: recording rule group 'test4' (namespace: testfgx) already exists
│ 
│   with module.mimir_recording_rule.mimir_rule_group_recording.record,
│   on modules/mimir_recording_rule/main.tf line 23, in resource "mimir_rule_group_recording" "record":
│   23: resource "mimir_rule_group_recording" "record" {
