### PR TITLE
feat: add delay provider parameters

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ provider "mimir" {
 
 ### Optional
 
+- `alertmanager_read_delay_after_change` (String) When set, add a delay (time duration) to read the alertmanager config after a change.
 - `alertmanager_uri` (String) mimir alertmanager base url
 - `ca` (String) Client ca (filepath or inline) for client authentication
 - `cert` (String) Client cert (filepath or inline) for client authentication
@@ -79,6 +80,7 @@ provider "mimir" {
 - `overwrite_rule_group_config` (Boolean) Overwrite the current rule group (alerting/recording) config on create.
 - `password` (String) When set, will use this password for BASIC auth to the API.
 - `proxy_url` (String) URL to the proxy to be used for all API requests
+- `rule_group_read_delay_after_change` (String) When set, add a delay (time duration) to read the rule group after a change.
 - `ruler_uri` (String) mimir ruler base url
 - `timeout` (Number) When set, will cause requests taking longer than this time (in seconds) to be aborted.
 - `token` (String) When set, will use this token for Bearer auth to the API.

--- a/mimir/resource_mimir_alertmanager_config.go
+++ b/mimir/resource_mimir_alertmanager_config.go
@@ -3,7 +3,9 @@ package mimir
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -51,18 +53,42 @@ func resourcemimirAlertmanagerConfigCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	d.SetId(client.headers["X-Scope-OrgID"])
+
+	// Retry read as mimir api could return a 404 status code caused by the event change notification propagation.
+	// Add delay of <alertmanagerReadDelayAfterChange> * time.Second) between each retry with a 3 max retries.
+	for i := 1; i < 4; i++ {
+		result := resourcemimirAlertmanagerConfigRead(ctx, d, meta)
+		if len(result) > 0 && !result.HasError() {
+			log.Printf("[WARN] Alertmanager config previously created not found (%d/3)", i)
+			time.Sleep(alertmanagerReadDelayAfterChangeDuration)
+			continue
+		}
+		return result
+	}
 	return resourcemimirAlertmanagerConfigRead(ctx, d, meta)
 }
 
 func resourcemimirAlertmanagerConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	client := meta.(*apiClient)
+
 	resp, err := client.sendRequest("alertmanager", "GET", apiAlertsPath, "", make(map[string]string))
 	baseMsg := "Cannot read alertmanager config"
 	err = handleHTTPError(err, baseMsg)
 	if err != nil {
-		if strings.Contains(err.Error(), "response code '404'") {
+		if d.IsNewResource() && strings.Contains(err.Error(), "response code '404'") {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Alertmanager config not found. You should increase the provider parameter 'alertmanager_read_delay_after_change' (current: %s)", alertmanagerReadDelayAfterChange),
+			})
+			return diags
+		} else if !d.IsNewResource() && strings.Contains(err.Error(), "response code '404'") {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Alertmanager config (id: %s) not found, removing from state", d.Id()),
+			})
 			d.SetId("")
-			return nil
+			return diags
 		}
 		return diag.FromErr(err)
 	}
@@ -103,7 +129,7 @@ func resourcemimirAlertmanagerConfigRead(ctx context.Context, d *schema.Resource
 		return diag.Errorf("error setting item: %v", err)
 	}
 
-	return diag.Diagnostics{}
+	return diags
 }
 
 func resourcemimirAlertmanagerConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -114,6 +140,8 @@ func resourcemimirAlertmanagerConfigUpdate(ctx context.Context, d *schema.Resour
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	// Add time delay before read to wait the event change notification propagation to finish
+	time.Sleep(alertmanagerReadDelayAfterChangeDuration)
 	return resourcemimirAlertmanagerConfigRead(ctx, d, meta)
 }
 


### PR DESCRIPTION
Add 2 provider parameters:
-  `alertmanager_read_delay_after_change` (default: **1s**)
-  `rule_group_read_delay_after_change` (default: **1s**)

This change try to render more reliable, resources update because mimir api could return an inconsistent result caused by the event change notification propagation latency.

Cf: https://grafana.slack.com/archives/C039863E8P7/p1698325205144159