### PR TITLE
fix: datasource_recording_rule_group labels key missing

### DIFF
--- a/mimir/data_source_mimir_rule_group_recording.go
+++ b/mimir/data_source_mimir_rule_group_recording.go
@@ -53,6 +53,12 @@ func dataSourcemimirRuleGroupRecording() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"labels": {
+							Type:        schema.TypeMap,
+							Description: "Recording Rule labels",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Fixes https://github.com/fgouteroux/terraform-provider-mimir/issues/27