### PR TITLE
feat(mimir-provider): Update deprecated mimir v1 endpoint to v2

### DIFF
--- a/mimir/provider.go
+++ b/mimir/provider.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	apiAlertsPath                            = "/api/v1/alerts"
+	apiAlertsPath                            = "/api/v2/alerts"
 	enablePromQLExprFormat                   bool
 	overwriteAlertmanagerConfig              bool
 	overwriteRuleGroupConfig                 bool


### PR DESCRIPTION
Alertmanager deprecated the v1 API. All v1 API endpoints now respond with a JSON deprecation notice and a status code of 410.
All endpoints have a v2 equivalent.