### PR TITLE
fix: check if location is nil before calling string

### DIFF
--- a/mimir/structures_alertmanager_config.go
+++ b/mimir/structures_alertmanager_config.go
@@ -1936,13 +1936,18 @@ func flattenTimeIntervalConfig(v []timeinterval.TimeInterval) []interface{} {
 	}
 
 	for _, v := range v {
+		location := ""
+		if v.Location != nil {
+			location = v.Location.String()
+		}
+
 		cfg := make(map[string]interface{})
 		cfg["times"] = flattenTimeRange(v.Times)
 		cfg["weekdays"] = flattenWeekdayRange(v.Weekdays)
 		cfg["days_of_month"] = flattenDayOfMonthRange(v.DaysOfMonth)
 		cfg["months"] = flattenMonthRange(v.Months)
 		cfg["years"] = flattenYearRange(v.Years)
-		cfg["location"] = v.Location.String()
+		cfg["location"] = location
 		timeIntervalConf = append(timeIntervalConf, cfg)
 	}
 	return timeIntervalConf


### PR DESCRIPTION
`TimeInterval.Location` is a pointer value and can be `nil`. When it is `nil`, attempting to call `.String()` results in a nil pointer dereference panic.

This change sets the location to be an empty string if the `Location` pointer is `nil`.

Fixes the following stack trace:

``` plain
╷
│ Error: Plugin did not respond
│
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadResource call. The plugin logs may contain more details.
╵


Stack trace from the terraform-provider-mimir_v0.2.6.exe plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0xf36536]

goroutine 49 [running]:
github.com/fgouteroux/terraform-provider-mimir/mimir.flattenTimeIntervalConfig({0xc00080c400?, 0x1, 0x11d72f1?})
        github.com/fgouteroux/terraform-provider-mimir/mimir/structures_alertmanager_config.go:1945 +0x3f6
github.com/fgouteroux/terraform-provider-mimir/mimir.flattenMuteTimeIntervalConfig({0xc0006b0920?, 0x1, 0x8000?})
        github.com/fgouteroux/terraform-provider-mimir/mimir/structures_alertmanager_config.go:1711 +0x11e
github.com/fgouteroux/terraform-provider-mimir/mimir.resourcemimirAlertmanagerConfigRead({0x158c508?, 0xc0008b5650?}, 0xc00073f880, {0x10be5e0?, 0xc00080a2d0})
        github.com/fgouteroux/terraform-provider-mimir/mimir/resource_mimir_alertmanager_config.go:123 +0x7f0
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc000620700, {0x158c508, 0xc0008b5650}, 0xd?, {0x10be5e0, 0xc00080a2d0})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/resource.go:750 +0x11b
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000620700, {0x158c508, 0xc0008b5650}, 0xc0008d5110, {0x10be5e0, 0xc00080a2d0})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/resource.go:1044 +0x552
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc0004e7b18, {0x158c508?, 0xc0008b5560?}, 0xc00075e500)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/grpc_provider.go:616 +0x48a
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0xc0000afc20, {0x158c508?, 0xc0008b4ba0?}, 0xc00073a780)
        github.com/hashicorp/terraform-plugin-go@v0.16.0/tfprotov5/tf5server/server.go:751 +0x48b
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0x119e700?, 0xc0000afc20}, {0x158c508, 0xc0008b4ba0}, 0xc0004744d0, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.16.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:386 +0x169
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000b83c0, {0x1590c00, 0xc0004831e0}, 0xc000822b40, 0xc000610720, 0x1c1d3f0, 0x0)
        google.golang.org/grpc@v1.56.0/server.go:1337 +0xde7
google.golang.org/grpc.(*Server).handleStream(0xc0000b83c0, {0x1590c00, 0xc0004831e0}, 0xc000822b40, 0x0)
        google.golang.org/grpc@v1.56.0/server.go:1714 +0x9e7
google.golang.org/grpc.(*Server).serveStreams.func1.1()
        google.golang.org/grpc@v1.56.0/server.go:959 +0x8d
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 68
        google.golang.org/grpc@v1.56.0/server.go:957 +0x165

Error: The terraform-provider-mimir_v0.2.6.exe plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```