### PR TITLE
Changes to interval or source tenants should run update

### DIFF
--- a/mimir/resource_mimir_rule_group_alerting.go
+++ b/mimir/resource_mimir_rule_group_alerting.go
@@ -211,7 +211,7 @@ func resourcemimirRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceD
 }
 
 func resourcemimirRuleGroupAlertingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChange("rule") {
+	if d.HasChanges("rule", "interval", "source_tenants") {
 		client := meta.(*apiClient)
 		name := d.Get("name").(string)
 		namespace := d.Get("namespace").(string)

--- a/mimir/resource_mimir_rule_group_alerting.go
+++ b/mimir/resource_mimir_rule_group_alerting.go
@@ -211,7 +211,7 @@ func resourcemimirRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceD
 }
 
 func resourcemimirRuleGroupAlertingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChanges("rule", "interval", "source_tenants") {
+	if d.HasChanges("rule", "source_tenants") {
 		client := meta.(*apiClient)
 		name := d.Get("name").(string)
 		namespace := d.Get("namespace").(string)

--- a/mimir/resource_mimir_rule_group_alerting_test.go
+++ b/mimir/resource_mimir_rule_group_alerting_test.go
@@ -183,6 +183,32 @@ func TestAccResourceRuleGroupAlerting_Federated(t *testing.T) {
 					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "rule.0.expr", "test1_metric"),
 				),
 			},
+			{
+				Config: testAccResourceRuleGroupAlerting_federated_rule_group_tenant_change,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.alert_1_federated_rule_group", "alert_1_federated_rule_group", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "name", "alert_1_federated_rule_group"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "source_tenants.0", "tenant-a"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "source_tenants.1", "tenant-c"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "source_tenants.2", "tenant-d"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "rule.0.alert", "test1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "rule.0.expr", "test1_metric"),
+				),
+			},
+			{
+				Config: testAccResourceRuleGroupAlerting_federated_rule_group_rule_change,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.alert_1_federated_rule_group", "alert_1_federated_rule_group", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "name", "alert_1_federated_rule_group"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "source_tenants.0", "tenant-a"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "source_tenants.1", "tenant-c"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "source_tenants.2", "tenant-d"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "rule.0.alert", "test2"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_federated_rule_group", "rule.0.expr", "test2_metric"),
+				),
+			},
 		},
 	})
 }
@@ -272,6 +298,30 @@ const testAccResourceRuleGroupAlerting_federated_rule_group = `
 		rule {
 			alert = "test1"
 			expr  = "test1_metric"
+		}
+	}
+`
+
+const testAccResourceRuleGroupAlerting_federated_rule_group_tenant_change = `
+	resource "mimir_rule_group_alerting" "alert_1_federated_rule_group" {
+		name = "alert_1_federated_rule_group"
+		source_tenants = ["tenant-a", "tenant-c", "tenant-d"]
+		namespace = "namespace_1"
+		rule {
+			alert = "test1"
+			expr  = "test1_metric"
+		}
+	}
+`
+
+const testAccResourceRuleGroupAlerting_federated_rule_group_rule_change = `
+	resource "mimir_rule_group_alerting" "alert_1_federated_rule_group" {
+		name = "alert_1_federated_rule_group"
+		source_tenants = ["tenant-a", "tenant-c", "tenant-d"]
+		namespace = "namespace_1"
+		rule {
+			alert = "test2"
+			expr  = "test2_metric"
 		}
 	}
 `

--- a/mimir/resource_mimir_rule_group_recording.go
+++ b/mimir/resource_mimir_rule_group_recording.go
@@ -200,7 +200,7 @@ func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resource
 }
 
 func resourcemimirRuleGroupRecordingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChange("rule") {
+	if d.HasChanges("rule", "interval", "source_tenants") {
 		client := meta.(*apiClient)
 		name := d.Get("name").(string)
 		namespace := d.Get("namespace").(string)

--- a/mimir/resource_mimir_rule_group_recording_test.go
+++ b/mimir/resource_mimir_rule_group_recording_test.go
@@ -123,6 +123,17 @@ func TestAccResourceRuleGroupRecording_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "interval", "6h"),
 				),
 			},
+			{
+				Config: testAccResourceRuleGroupRecording_interval_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_interval", "record_1_interval", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "name", "record_1_interval"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "rule.0.record", "test1_info"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "rule.0.expr", "test1_metric"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "interval", "10m"),
+				),
+			},
 		},
 	})
 }
@@ -149,6 +160,30 @@ func TestAccResourceRuleGroupRecording_Federated(t *testing.T) {
 					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "source_tenants.1", "tenant-b"),
 					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "rule.0.record", "test1_info"),
 					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "rule.0.expr", "test1_metric"),
+				),
+			},
+			{
+				Config: testAccResourceRuleGroupRecording_federated_rule_group_tenant_change,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_federated_rule_group", "record_1_federated_rule_group", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "name", "record_1_federated_rule_group"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "source_tenants.0", "tenant-a"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "source_tenants.1", "tenant-c"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "rule.0.record", "test1_info"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "rule.0.expr", "test1_metric"),
+				),
+			},
+			{
+				Config: testAccResourceRuleGroupRecording_federated_rule_group_rule_change,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_federated_rule_group", "record_1_federated_rule_group", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "name", "record_1_federated_rule_group"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "source_tenants.0", "tenant-a"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "source_tenants.1", "tenant-c"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "rule.0.record", "test2_info"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_federated_rule_group", "rule.0.expr", "test2_metric"),
 				),
 			},
 		},
@@ -196,11 +231,47 @@ const testAccResourceRuleGroupRecording_federated_rule_group = `
 	}
 `
 
+const testAccResourceRuleGroupRecording_federated_rule_group_tenant_change = `
+	resource "mimir_rule_group_recording" "record_1_federated_rule_group" {
+		name = "record_1_federated_rule_group"
+		namespace = "namespace_1"
+		source_tenants = ["tenant-a", "tenant-c"]
+		rule {
+			record = "test1_info"
+			expr   = "test1_metric"
+		}
+	}
+`
+
+const testAccResourceRuleGroupRecording_federated_rule_group_rule_change = `
+	resource "mimir_rule_group_recording" "record_1_federated_rule_group" {
+		name = "record_1_federated_rule_group"
+		namespace = "namespace_1"
+		source_tenants = ["tenant-a", "tenant-c"]
+		rule {
+			record = "test2_info"
+			expr   = "test2_metric"
+		}
+	}
+`
+
 const testAccResourceRuleGroupRecording_interval = `
     resource "mimir_rule_group_recording" "record_1_interval" {
             name = "record_1_interval"
             namespace = "namespace_1"
             interval = "6h"
+            rule {
+                    record = "test1_info"
+                    expr   = "test1_metric"
+            }
+    }
+`
+
+const testAccResourceRuleGroupRecording_interval_update = `
+    resource "mimir_rule_group_recording" "record_1_interval" {
+            name = "record_1_interval"
+            namespace = "namespace_1"
+            interval = "10m"
             rule {
                     record = "test1_info"
                     expr   = "test1_metric"


### PR DESCRIPTION
## Summary

The module currently runs an update iff a rule changes, but there are other ways to update a rule group, and currently, they won't actually trigger a change in Mimir, _but Terraform will report the diff_.

## Evidence

```
Terraform will perform the following actions:
  # mimir_rule_group_recording.this["system-resources"] will be updated in-place
  ~ resource "mimir_rule_group_recording" "this" {
        id             = "system/resources"
      ~ interval       = "10m" -> "1h"
        name           = "resources"
      ~ source_tenants = [
          - "vertica_prod",
          + "vertica_staging",
        ]
        # (1 unchanged attribute hidden)
        # (2 unchanged blocks hidden)
    }
Plan: 0 to add, 1 to change, 0 to destroy.
```

I ran a job to update the interval and source tenants (at first it was only the interval).
Terraform reported the change and said it would run an update in-place, but this never happened.
I came back an hour later, very confused that my source tenant and interval were still the same as before, and wondered what would happen if I poked a trivial change in a rule - and that triggered the change to complete.

So, I wondered if it was because these keys weren't being checked when running the update, which it seems it was indeed the case that these keys were ignored when checking rule groups for updates.

To test this, I added test cases into into the recording rule tests to check if a change that only changes the interval or source tenants would actually be applied.
Without any modifications, they were not, and the test cases would fail.

After swapping the `if` check to use `HasChanges`, these failures are resolved and the tests pass.

## Testing methodology

I relied on [the `docker-compose` found in the Grafana Mimir `Play With Mimir` pages](https://github.com/grafana/mimir/tree/main/docs/sources/mimir/get-started/play-with-grafana-mimir) and added two command-line options to the Mimir containers: `"-tenant-federation.enabled=true", "-ruler.tenant-federation.enabled"`.

Then, as required, I ran a few exports:
```
export MIMIR_URI=http://localhost:9009
export MIMIR_RULER_URI=http://localhost:9009/prometheus
export MIMIR_ALERTMANAGER_URI=http://localhost:9009
```

And executed `make testacc`.

Before adding the changes in this PR:

```
=== RUN   TestAccResourceRuleGroupRecording_Basic
    resource_mimir_rule_group_recording_test.go:87: Step 4/4 error: Check failed: Check 6/6 error: mimir_rule_group_recording.record_1_interval: Attribute 'interval' expected "10m", got "6h"
--- FAIL: TestAccResourceRuleGroupRecording_Basic (3.65s)
=== RUN   TestAccResourceRuleGroupRecording_Federated
    resource_mimir_rule_group_recording_test.go:148: Step 2/2 error: Check failed: Check 5/7 error: mimir_rule_group_recording.record_1_federated_rule_group: Attribute 'source_tenants.1' expected "tenant-c", got "tenant-b"
--- FAIL: TestAccResourceRuleGroupRecording_Federated (1.82s)
```

There were no more failures after the changes indicated in this PR.

For completeness, I also added a similar test case to alerting rules.