### PR TITLE
feat: add evaluation_period for recording rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ Example:
 
 ```
 resource "mimir_rule_group_recording" "record" {
-  name      = "test1"
-  namespace = "namespace1"
-  interval  = "6h"
+  name         = "test1"
+  namespace    = "namespace1"
+  interval     = "6h"
+  query_offset = "5m"
   rule {
     expr   = "sum by (job) (http_inprogress_requests)"
     record = "job:http_inprogress_requests:sum"

--- a/docs/data-sources/rule_group_recording.md
+++ b/docs/data-sources/rule_group_recording.md
@@ -33,7 +33,8 @@ data "mimir_rule_group_recording" "record" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `interval` (String) Recording Rule group interval
+- `interval` (String) Recording Rule group interval.
+- `query_offset` (String) The duration by which to delay the execution of the recording rule.
 - `rule` (List of Object) (see [below for nested schema](#nestedatt--rule))
 - `source_tenants` (List of String) Allows aggregating data from multiple tenants while evaluating a rule group.
 

--- a/docs/data-sources/rule_group_recording.md
+++ b/docs/data-sources/rule_group_recording.md
@@ -34,7 +34,7 @@ data "mimir_rule_group_recording" "record" {
 
 - `id` (String) The ID of this resource.
 - `interval` (String) Recording Rule group interval.
-- `query_offset` (String) The duration by which to delay the execution of the recording rule.
+- `evaluation_delay` (String) The duration by which to delay the execution of the recording rule.
 - `rule` (List of Object) (see [below for nested schema](#nestedatt--rule))
 - `source_tenants` (List of String) Allows aggregating data from multiple tenants while evaluating a rule group.
 

--- a/docs/resources/rule_group_recording.md
+++ b/docs/resources/rule_group_recording.md
@@ -14,10 +14,10 @@ description: |-
 
 ```terraform
 resource "mimir_rule_group_recording" "test" {
-  name          = "test1"
-  namespace     = "namespace1"
-  interval      = "6h"
-  query_offset  = "5m"
+  name              = "test1"
+  namespace         = "namespace1"
+  interval          = "6h"
+  evaluation_delay  = "5m"
   rule {
     expr   = "sum by (job) (http_inprogress_requests)"
     record = "job:http_inprogress_requests:sum"
@@ -36,7 +36,7 @@ resource "mimir_rule_group_recording" "test" {
 ### Optional
 
 - `interval` (String) Recording Rule group interval.
-- `query_offset` (String) The duration by which to delay the execution of the recording rule.
+- `evaluation_delay` (String) The duration by which to delay the execution of the recording rule.
 - `namespace` (String) Recording Rule group namespace.
 - `source_tenants` (List of String) Allows aggregating data from multiple tenants while evaluating a rule group.
 

--- a/docs/resources/rule_group_recording.md
+++ b/docs/resources/rule_group_recording.md
@@ -14,9 +14,10 @@ description: |-
 
 ```terraform
 resource "mimir_rule_group_recording" "test" {
-  name      = "test1"
-  namespace = "namespace1"
-  interval  = "6h"
+  name          = "test1"
+  namespace     = "namespace1"
+  interval      = "6h"
+  query_offset  = "5m"
   rule {
     expr   = "sum by (job) (http_inprogress_requests)"
     record = "job:http_inprogress_requests:sum"
@@ -34,8 +35,9 @@ resource "mimir_rule_group_recording" "test" {
 
 ### Optional
 
-- `interval` (String) Recording Rule group interval
-- `namespace` (String) Recording Rule group namespace
+- `interval` (String) Recording Rule group interval.
+- `query_offset` (String) The duration by which to delay the execution of the recording rule.
+- `namespace` (String) Recording Rule group namespace.
 - `source_tenants` (List of String) Allows aggregating data from multiple tenants while evaluating a rule group.
 
 ### Read-Only

--- a/mimir/data_source_mimir_rule_group_recording.go
+++ b/mimir/data_source_mimir_rule_group_recording.go
@@ -34,7 +34,7 @@ func dataSourcemimirRuleGroupRecording() *schema.Resource {
 				Description: "Recording Rule group interval",
 				Computed:    true,
 			},
-			"query_offset": {
+			"evaluation_delay": {
 				Type:        schema.TypeString,
 				Description: "The duration by which to delay the execution of the recording rule.",
 				Computed:    true,
@@ -104,7 +104,7 @@ func dataSourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resour
 	if err := d.Set("interval", data.Interval); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("query_offset", data.QueryOffset); err != nil {
+	if err := d.Set("evaluation_delay", data.EvaluationDelay); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("source_tenants", data.SourceTenants); err != nil {

--- a/mimir/data_source_mimir_rule_group_recording.go
+++ b/mimir/data_source_mimir_rule_group_recording.go
@@ -34,6 +34,11 @@ func dataSourcemimirRuleGroupRecording() *schema.Resource {
 				Description: "Recording Rule group interval",
 				Computed:    true,
 			},
+			"query_offset": {
+				Type:        schema.TypeString,
+				Description: "The duration by which to delay the execution of the recording rule.",
+				Computed:    true,
+			},
 			"source_tenants": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -97,6 +102,9 @@ func dataSourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	if err := d.Set("interval", data.Interval); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("query_offset", data.QueryOffset); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("source_tenants", data.SourceTenants); err != nil {

--- a/mimir/resource_mimir_rule_group_recording.go
+++ b/mimir/resource_mimir_rule_group_recording.go
@@ -42,7 +42,7 @@ func resourcemimirRuleGroupRecording() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validateDuration,
 			},
-			"query_offset": {
+			"evaluation_delay": {
 				Type:         schema.TypeString,
 				Description:  "The duration by which to delay the execution of the recording rule.",
 				Optional:     true,
@@ -112,11 +112,11 @@ func resourcemimirRuleGroupRecordingCreate(ctx context.Context, d *schema.Resour
 	}
 
 	rules := &recordingRuleGroup{
-		Name:          name,
-		Interval:      d.Get("interval").(string),
-		QueryOffset:   d.Get("query_offset").(string),
-		SourceTenants: expandStringArray(d.Get("source_tenants").([]interface{})),
-		Rules:         expandRecordingRules(d.Get("rule").([]interface{})),
+		Name:            name,
+		Interval:        d.Get("interval").(string),
+		EvaluationDelay: d.Get("evaluation_delay").(string),
+		SourceTenants:   expandStringArray(d.Get("source_tenants").([]interface{})),
+		Rules:           expandRecordingRules(d.Get("rule").([]interface{})),
 	}
 	data, _ := yaml.Marshal(rules)
 	headers := map[string]string{"Content-Type": "application/yaml"}
@@ -199,7 +199,7 @@ func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resource
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("query_offset", data.QueryOffset)
+	err = d.Set("evaluation_delay", data.EvaluationDelay)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -211,17 +211,17 @@ func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resource
 }
 
 func resourcemimirRuleGroupRecordingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChanges("rule", "interval", "source_tenants") {
+	if d.HasChanges("rule", "interval", "evaluation_delay", "source_tenants") {
 		client := meta.(*apiClient)
 		name := d.Get("name").(string)
 		namespace := d.Get("namespace").(string)
 
 		rules := &recordingRuleGroup{
-			Name:          name,
-			Interval:      d.Get("interval").(string),
-			QueryOffset:   d.Get("query_offset").(string),
-			SourceTenants: expandStringArray(d.Get("source_tenants").([]interface{})),
-			Rules:         expandRecordingRules(d.Get("rule").([]interface{})),
+			Name:            name,
+			Interval:        d.Get("interval").(string),
+			EvaluationDelay: d.Get("evaluation_delay").(string),
+			SourceTenants:   expandStringArray(d.Get("source_tenants").([]interface{})),
+			Rules:           expandRecordingRules(d.Get("rule").([]interface{})),
 		}
 		data, _ := yaml.Marshal(rules)
 		headers := map[string]string{"Content-Type": "application/yaml"}
@@ -325,9 +325,9 @@ type recordingRule struct {
 }
 
 type recordingRuleGroup struct {
-	Name          string          `yaml:"name"`
-	Interval      string          `yaml:"interval,omitempty"`
-	QueryOffset   string          `yaml:"query_offset,omitempty"`
-	Rules         []recordingRule `yaml:"rules"`
-	SourceTenants []string        `yaml:"source_tenants,omitempty"`
+	Name            string          `yaml:"name"`
+	Interval        string          `yaml:"interval,omitempty"`
+	EvaluationDelay string          `yaml:"evaluation_delay,omitempty"`
+	Rules           []recordingRule `yaml:"rules"`
+	SourceTenants   []string        `yaml:"source_tenants,omitempty"`
 }

--- a/mimir/resource_mimir_rule_group_recording.go
+++ b/mimir/resource_mimir_rule_group_recording.go
@@ -42,6 +42,12 @@ func resourcemimirRuleGroupRecording() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validateDuration,
 			},
+			"query_offset": {
+				Type:         schema.TypeString,
+				Description:  "The duration by which to delay the execution of the recording rule.",
+				Optional:     true,
+				ValidateFunc: validateDuration,
+			},
 			"source_tenants": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -108,6 +114,7 @@ func resourcemimirRuleGroupRecordingCreate(ctx context.Context, d *schema.Resour
 	rules := &recordingRuleGroup{
 		Name:          name,
 		Interval:      d.Get("interval").(string),
+		QueryOffset:   d.Get("query_offset").(string),
 		SourceTenants: expandStringArray(d.Get("source_tenants").([]interface{})),
 		Rules:         expandRecordingRules(d.Get("rule").([]interface{})),
 	}
@@ -192,6 +199,10 @@ func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resource
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	err = d.Set("query_offset", data.QueryOffset)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	err = d.Set("source_tenants", data.SourceTenants)
 	if err != nil {
 		return diag.FromErr(err)
@@ -208,6 +219,7 @@ func resourcemimirRuleGroupRecordingUpdate(ctx context.Context, d *schema.Resour
 		rules := &recordingRuleGroup{
 			Name:          name,
 			Interval:      d.Get("interval").(string),
+			QueryOffset:   d.Get("query_offset").(string),
 			SourceTenants: expandStringArray(d.Get("source_tenants").([]interface{})),
 			Rules:         expandRecordingRules(d.Get("rule").([]interface{})),
 		}
@@ -315,6 +327,7 @@ type recordingRule struct {
 type recordingRuleGroup struct {
 	Name          string          `yaml:"name"`
 	Interval      string          `yaml:"interval,omitempty"`
+	QueryOffset   string          `yaml:"query_offset,omitempty"`
 	Rules         []recordingRule `yaml:"rules"`
 	SourceTenants []string        `yaml:"source_tenants,omitempty"`
 }

--- a/mimir/resource_mimir_rule_group_recording_test.go
+++ b/mimir/resource_mimir_rule_group_recording_test.go
@@ -135,25 +135,25 @@ func TestAccResourceRuleGroupRecording_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceRuleGroupRecording_query_offset,
+				Config: testAccResourceRuleGroupRecording_evaluation_delay,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_query_offset", "record_1_query_offset", client),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "name", "record_1_query_offset"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "namespace", "namespace_1"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "rule.0.record", "test1_info"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "rule.0.expr", "test1_metric"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "query_offset", "5m"),
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_evaluation_delay", "record_1_evaluation_delay", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_evaluation_delay", "name", "record_1_evaluation_delay"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_evaluation_delay", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_evaluation_delay", "rule.0.record", "test1_info"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_evaluation_delay", "rule.0.expr", "test1_metric"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_evaluation_delay", "evaluation_delay", "5m"),
 				),
 			},
 			{
-				Config: testAccResourceRuleGroupRecording_query_offset_update,
+				Config: testAccResourceRuleGroupRecording_evaluation_delay_update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_query_offset", "record_1_query_offset", client),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "name", "record_1_query_offset"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "namespace", "namespace_1"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "rule.0.record", "test1_info"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "rule.0.expr", "test1_metric"),
-					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "query_offset", "1m"),
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_evaluation_delay", "record_1_evaluation_delay", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_evaluation_delay", "name", "record_1_evaluation_delay"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_evaluation_delay", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_evaluation_delay", "rule.0.record", "test1_info"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_evaluation_delay", "rule.0.expr", "test1_metric"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_evaluation_delay", "evaluation_delay", "1m"),
 				),
 			},
 		},
@@ -301,11 +301,11 @@ const testAccResourceRuleGroupRecording_interval_update = `
     }
 `
 
-const testAccResourceRuleGroupRecording_query_offset = `
-    resource "mimir_rule_group_recording" "record_1_query_offset" {
-            name = "record_1_query_offset"
+const testAccResourceRuleGroupRecording_evaluation_delay = `
+    resource "mimir_rule_group_recording" "record_1_evaluation_delay" {
+            name = "record_1_evaluation_delay"
             namespace = "namespace_1"
-            query_offset = "5m"
+            evaluation_delay = "5m"
             rule {
                     record = "test1_info"
                     expr   = "test1_metric"
@@ -313,11 +313,11 @@ const testAccResourceRuleGroupRecording_query_offset = `
     }
 `
 
-const testAccResourceRuleGroupRecording_query_offset_update = `
-    resource "mimir_rule_group_recording" "record_1_query_offset" {
-            name = "record_1_query_offset"
+const testAccResourceRuleGroupRecording_evaluation_delay_update = `
+    resource "mimir_rule_group_recording" "record_1_evaluation_delay" {
+            name = "record_1_evaluation_delay"
             namespace = "namespace_1"
-            query_offset = "1m"
+            evaluation_delay = "1m"
             rule {
                     record = "test1_info"
                     expr   = "test1_metric"

--- a/mimir/resource_mimir_rule_group_recording_test.go
+++ b/mimir/resource_mimir_rule_group_recording_test.go
@@ -134,6 +134,28 @@ func TestAccResourceRuleGroupRecording_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_interval", "interval", "10m"),
 				),
 			},
+			{
+				Config: testAccResourceRuleGroupRecording_query_offset,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_query_offset", "record_1_query_offset", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "name", "record_1_query_offset"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "rule.0.record", "test1_info"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "rule.0.expr", "test1_metric"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "query_offset", "5m"),
+				),
+			},
+			{
+				Config: testAccResourceRuleGroupRecording_query_offset_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_query_offset", "record_1_query_offset", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "name", "record_1_query_offset"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "rule.0.record", "test1_info"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "rule.0.expr", "test1_metric"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_query_offset", "query_offset", "1m"),
+				),
+			},
 		},
 	})
 }
@@ -272,6 +294,30 @@ const testAccResourceRuleGroupRecording_interval_update = `
             name = "record_1_interval"
             namespace = "namespace_1"
             interval = "10m"
+            rule {
+                    record = "test1_info"
+                    expr   = "test1_metric"
+            }
+    }
+`
+
+const testAccResourceRuleGroupRecording_query_offset = `
+    resource "mimir_rule_group_recording" "record_1_query_offset" {
+            name = "record_1_query_offset"
+            namespace = "namespace_1"
+            query_offset = "5m"
+            rule {
+                    record = "test1_info"
+                    expr   = "test1_metric"
+            }
+    }
+`
+
+const testAccResourceRuleGroupRecording_query_offset_update = `
+    resource "mimir_rule_group_recording" "record_1_query_offset" {
+            name = "record_1_query_offset"
+            namespace = "namespace_1"
+            query_offset = "1m"
             rule {
                     record = "test1_info"
                     expr   = "test1_metric"


### PR DESCRIPTION
Add `evaluation_period` support for recording rules.

The Prometheus spec mentions `query_offset`, but Mimir 2.12 does not yet support this: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule_group