### PR TITLE
feat: Make PromQL validation configurable

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,7 @@ provider "mimir" {
 - `debug` (Boolean) Enable debug mode to trace requests executed.
 - `distributor_uri` (String) mimir distributor base url
 - `format_promql_expr` (Boolean) Enable the formatting of PromQL expression.
+- `validate_promql_expr` (Boolean) Enable the validation of PromQL expression.
 - `headers` (Map of String) A map of header names and values to set on all outbound requests.
 - `insecure` (Boolean) When using https, this disables TLS verification of the host.
 - `key` (String) Client key (filepath or inline) for TLS client authentication.

--- a/mimir/provider.go
+++ b/mimir/provider.go
@@ -12,6 +12,7 @@ import (
 var (
 	apiAlertsPath                            = "/api/v1/alerts"
 	enablePromQLExprFormat                   bool
+	enablePromQLExprValidation               bool
 	overwriteAlertmanagerConfig              bool
 	overwriteRuleGroupConfig                 bool
 	ruleGroupReadDelayAfterChange            string
@@ -129,6 +130,12 @@ func Provider(version string) func() *schema.Provider {
 					DefaultFunc: schema.EnvDefaultFunc("MIMIR_FORMAT_PROMQL_EXPR", false),
 					Description: "Enable the formatting of PromQL expression.",
 				},
+				"validate_promql_expr": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("MIMIR_VALIDATE_PROMQL_EXPR", true),
+					Description: "Enable the validation of PromQL expression.",
+				},
 				"overwrite_alertmanager_config": {
 					Type:        schema.TypeBool,
 					Optional:    true,
@@ -217,6 +224,7 @@ func providerConfigure(version string, p *schema.Provider, d *schema.ResourceDat
 	}
 
 	enablePromQLExprFormat = d.Get("format_promql_expr").(bool)
+	enablePromQLExprValidation = d.Get("validate_promql_expr").(bool)
 	overwriteAlertmanagerConfig = d.Get("overwrite_alertmanager_config").(bool)
 	overwriteRuleGroupConfig = d.Get("overwrite_rule_group_config").(bool)
 	ruleGroupReadDelayAfterChange = d.Get("rule_group_read_delay_after_change").(string)

--- a/mimir/resource_mimir_rule_group_alerting_test.go
+++ b/mimir/resource_mimir_rule_group_alerting_test.go
@@ -262,7 +262,7 @@ func TestAccResourceRuleGroupAlerting_FormatPromQLExpr(t *testing.T) {
 	os.Setenv("MIMIR_FORMAT_PROMQL_EXPR", "false")
 }
 
-func TestAccResourceRuleGroupAlerting_ValidatePromQLExpr(t *testing.T) {
+func TestAccResourceRuleGroupAlerting_SkipValidationPromQLExpr(t *testing.T) {
 	// Init client
 	client, err := NewAPIClient(setupClient())
 	if err != nil {
@@ -275,7 +275,7 @@ func TestAccResourceRuleGroupAlerting_ValidatePromQLExpr(t *testing.T) {
 		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceRuleGroupAlerting_expectPromQLValidationError,
+				Config: testAccResourceRuleGroupAlerting_skip_promql_validation,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.alert_1", "alert_1", client),
 					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1", "name", "alert_1"),
@@ -395,6 +395,17 @@ const testAccResourceRuleGroupAlerting_federated_rule_group_rule_change = `
 		rule {
 			alert = "test2"
 			expr  = "test2_metric"
+		}
+	}
+`
+
+const testAccResourceRuleGroupAlerting_skip_promql_validation = `
+	resource "mimir_rule_group_alerting" "alert_1" {
+		name = "alert_1"
+		namespace = "namespace_1"
+		rule {
+			alert = "test1_alert"
+			expr   = "rate(hi)"
 		}
 	}
 `

--- a/mimir/shared.go
+++ b/mimir/shared.go
@@ -59,13 +59,14 @@ func validateGroupRuleName(v interface{}, k string) (ws []string, errors []error
 }
 
 func validatePromQLExpr(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
+	if enablePromQLExprValidation {
+		value := v.(string)
 
-	if _, err := parser.ParseExpr(value); err != nil {
-		errors = append(errors, fmt.Errorf(
-			"\"%s\": Invalid PromQL expression %q: %v", k, value, err))
+		if _, err := parser.ParseExpr(value); err != nil {
+			errors = append(errors, fmt.Errorf(
+				"\"%s\": Invalid PromQL expression %q: %v", k, value, err))
+		}
 	}
-
 	return
 }
 


### PR DESCRIPTION
This PR makes the PromQL expression validation configurable so DataSources not compatible with Prometheus can be used.