### PR TITLE
feat: allow nested route in mimir_alertmanager_config

### DIFF
--- a/docs/data-sources/alertmanager_config.md
+++ b/docs/data-sources/alertmanager_config.md
@@ -1312,6 +1312,7 @@ Read-Only:
 Read-Only:
 
 - `active_time_intervals` (List of String)
+- `child_route` (List of Object) (see [below for nested schema](#nestedobjatt--route--child_route--child_route))
 - `continue` (Boolean)
 - `group_by` (List of String)
 - `group_interval` (String)
@@ -1320,6 +1321,39 @@ Read-Only:
 - `mute_time_intervals` (List of String)
 - `receiver` (String)
 - `repeat_interval` (String)
+
+<a id="nestedobjatt--route--child_route--child_route"></a>
+### Nested Schema for `route.child_route.child_route`
+
+Read-Only:
+
+- `active_time_intervals` (List of String)
+- `child_route` (List of Object) (see [below for nested schema](#nestedobjatt--route--child_route--child_route--child_route))
+- `continue` (Boolean)
+- `group_by` (List of String)
+- `group_interval` (String)
+- `group_wait` (String)
+- `matchers` (List of String)
+- `mute_time_intervals` (List of String)
+- `receiver` (String)
+- `repeat_interval` (String)
+
+<a id="nestedobjatt--route--child_route--child_route--child_route"></a>
+### Nested Schema for `route.child_route.child_route.repeat_interval`
+
+Read-Only:
+
+- `active_time_intervals` (List of String)
+- `continue` (Boolean)
+- `group_by` (List of String)
+- `group_interval` (String)
+- `group_wait` (String)
+- `matchers` (List of String)
+- `mute_time_intervals` (List of String)
+- `receiver` (String)
+- `repeat_interval` (String)
+
+
 
 
 

--- a/docs/resources/alertmanager_config.md
+++ b/docs/resources/alertmanager_config.md
@@ -19,14 +19,36 @@ resource "mimir_alertmanager_config" "mytenant" {
     group_wait = "30s"
     group_interval = "5m"
     repeat_interval = "1h"
-    receiver = "pagerduty"
+    receiver = "pagerduty_dev"
+  }
+  child_route {
+    matchers = ["severity=\"critical\""]
+
+    child_route {
+      receiver = "pagerduty_prod"
+      matchers = ["environment=\"prod\""]
+    }
+
+    child_route {
+      receiver = "pagerduty_dev"
+      matchers = ["environment=\"dev\""]
+    }
   }
   receiver {
-    name = "pagerduty"
+    name = "pagerduty_dev"
     pagerduty_configs {
       routing_key = "secret"
       details = {
         environment = "dev"
+      }
+    }
+  }
+  receiver {
+    name = "pagerduty_prod"
+    pagerduty_configs {
+      routing_key = "secret"
+      details = {
+        environment = "prod"
       }
     }
   }
@@ -1231,9 +1253,37 @@ Optional:
 <a id="nestedblock--route--child_route"></a>
 ### Nested Schema for `route.child_route`
 
-Required:
+Optional:
 
+- `active_time_intervals` (List of String) Times when the route should be active. These must match the name of a mute time interval defined in the time_interval block.
+- `child_route` (Block List) Although the `child_route` block is recursive, only 3 levels are supported by default. It could be defined by `MIMIR_ALERTMANAGER_CHILD_ROUTE_MAX_LEVEL` env var. (see [below for nested schema](#nestedblock--route--child_route--child_route))
+- `continue` (Boolean) Whether an alert should continue matching subsequent sibling nodes.
+- `group_by` (List of String) The labels by which incoming alerts are grouped together.
+- `group_interval` (String) How long to wait before sending a notification about new alerts that are added to a group of alerts for which an initial notification has already been sent.
+- `group_wait` (String) How long to initially wait to send a notification for a group of alerts. Allows to wait for an inhibiting alert to arrive or collect more initial alerts for the same group.
+- `matchers` (List of String) A list of matchers that an alert has to fulfill to match the node.
+- `mute_time_intervals` (List of String) Times when the route should be muted. These must match the name of a mute time interval defined in the time_interval block.
 - `receiver` (String) Name of the receiver to send the notification.
+- `repeat_interval` (String) How long to wait before sending a notification again if it has already been sent successfully for an alert.
+
+<a id="nestedblock--route--child_route--child_route"></a>
+### Nested Schema for `route.child_route.child_route`
+
+Optional:
+
+- `active_time_intervals` (List of String) Times when the route should be active. These must match the name of a mute time interval defined in the time_interval block.
+- `child_route` (Block List) Although the `child_route` block is recursive, only 3 levels are supported by default. It could be defined by `MIMIR_ALERTMANAGER_CHILD_ROUTE_MAX_LEVEL` env var. (see [below for nested schema](#nestedblock--route--child_route--child_route--child_route))
+- `continue` (Boolean) Whether an alert should continue matching subsequent sibling nodes.
+- `group_by` (List of String) The labels by which incoming alerts are grouped together.
+- `group_interval` (String) How long to wait before sending a notification about new alerts that are added to a group of alerts for which an initial notification has already been sent.
+- `group_wait` (String) How long to initially wait to send a notification for a group of alerts. Allows to wait for an inhibiting alert to arrive or collect more initial alerts for the same group.
+- `matchers` (List of String) A list of matchers that an alert has to fulfill to match the node.
+- `mute_time_intervals` (List of String) Times when the route should be muted. These must match the name of a mute time interval defined in the time_interval block.
+- `receiver` (String) Name of the receiver to send the notification.
+- `repeat_interval` (String) How long to wait before sending a notification again if it has already been sent successfully for an alert.
+
+<a id="nestedblock--route--child_route--child_route--child_route"></a>
+### Nested Schema for `route.child_route.child_route.child_route`
 
 Optional:
 
@@ -1244,7 +1294,10 @@ Optional:
 - `group_wait` (String) How long to initially wait to send a notification for a group of alerts. Allows to wait for an inhibiting alert to arrive or collect more initial alerts for the same group.
 - `matchers` (List of String) A list of matchers that an alert has to fulfill to match the node.
 - `mute_time_intervals` (List of String) Times when the route should be muted. These must match the name of a mute time interval defined in the time_interval block.
+- `receiver` (String) Name of the receiver to send the notification.
 - `repeat_interval` (String) How long to wait before sending a notification again if it has already been sent successfully for an alert.
+
+
 
 
 

--- a/examples/resources/mimir_alertmanager_config/resource.tf
+++ b/examples/resources/mimir_alertmanager_config/resource.tf
@@ -4,14 +4,36 @@ resource "mimir_alertmanager_config" "mytenant" {
     group_wait = "30s"
     group_interval = "5m"
     repeat_interval = "1h"
-    receiver = "pagerduty"
+    receiver = "pagerduty_dev"
+  }
+  child_route {
+    matchers = ["severity=\"critical\""]
+
+    child_route {
+      receiver = "pagerduty_prod"
+      matchers = ["environment=\"prod\""]
+    }
+
+    child_route {
+      receiver = "pagerduty_dev"
+      matchers = ["environment=\"dev\""]
+    }
   }
   receiver {
-    name = "pagerduty"
+    name = "pagerduty_dev"
     pagerduty_configs {
       routing_key = "secret"
       details = {
         environment = "dev"
+      }
+    }
+  }
+  receiver {
+    name = "pagerduty_prod"
+    pagerduty_configs {
+      routing_key = "secret"
+      details = {
+        environment = "prod"
       }
     }
   }

--- a/mimir/structures_alertmanager_config.go
+++ b/mimir/structures_alertmanager_config.go
@@ -1607,6 +1607,13 @@ func expandChildRouteConfig(v interface{}) *route {
 	data := v.([]interface{})
 	if len(data) != 0 && data[0] != nil {
 		cfg := data[0].(map[string]interface{})
+		if raw, ok := cfg["child_route"]; ok {
+			var routes []*route
+			for _, item := range raw.([]interface{}) {
+				routes = append(routes, expandChildRouteConfig([]interface{}{item.(map[string]interface{})}))
+			}
+			routeConf.Routes = routes
+		}
 		if raw, ok := cfg["receiver"]; ok {
 			routeConf.Receiver = raw.(string)
 		}
@@ -1674,6 +1681,14 @@ func flattenRouteConfig(v *route) []interface{} {
 
 func flattenChildRouteConfig(v *route) []interface{} {
 	routeConf := make(map[string]interface{})
+
+	if v.Routes != nil {
+		var routes []interface{}
+		for _, route := range v.Routes {
+			routes = append(routes, flattenChildRouteConfig(route)[0])
+		}
+		routeConf["child_route"] = routes
+	}
 
 	routeConf["receiver"] = v.Receiver
 


### PR DESCRIPTION
Fix the issue https://github.com/fgouteroux/terraform-provider-mimir/issues/40

Allow to define alertmanager nested route like:
```
resource "mimir_alertmanager_config" "mytenant" {
  route {
    group_by = ["..."]
    group_wait = "30s"
    group_interval = "5m"
    repeat_interval = "1h"
    receiver = "pagerduty_dev"
  }
  child_route {
    matchers = ["severity=\"critical\""]

    child_route {
      receiver = "pagerduty_prod"
      matchers = ["environment=\"prod\""]
    }

    child_route {
      receiver = "pagerduty_dev"
      matchers = ["environment=\"dev\""]
    }
  }
  receiver {
    name = "pagerduty_dev"
    pagerduty_configs {
      routing_key = "secret"
      details = {
        environment = "dev"
      }
    }
  }
  receiver {
    name = "pagerduty_prod"
    pagerduty_configs {
      routing_key = "secret"
      details = {
        environment = "prod"
      }
    }
  }
}
```