### PR TITLE
fix: add wait/retry check after deleting a resource

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -39,3 +39,7 @@ text = "ST1003: should not use underscores in Go names;"
 [[issues.exclude-rules]]
 linters = ["gosec"]
 text = "G402: TLS MinVersion too low."
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "G115: integer overflow conversion"

--- a/mimir/resource_mimir_rule_group_recording.go
+++ b/mimir/resource_mimir_rule_group_recording.go
@@ -146,19 +146,13 @@ func resourcemimirRuleGroupRecordingCreate(ctx context.Context, d *schema.Resour
 
 func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	client := meta.(*apiClient)
 
 	// use id as read is also called by import
 	idArr := strings.Split(d.Id(), "/")
 	namespace := idArr[0]
 	name := idArr[1]
 
-	var headers map[string]string
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
-	jobraw, err := client.sendRequest("ruler", "GET", path, "", headers)
-
-	baseMsg := fmt.Sprintf("Cannot read recording rule group '%s' (namespace: %s) -", name, namespace)
-	err = handleHTTPError(err, baseMsg)
+	jobraw, err := ruleGroupRecordingRead(meta, name, namespace)
 	if err != nil {
 		if d.IsNewResource() && strings.Contains(err.Error(), "response code '404'") {
 			diags = append(diags, diag.Diagnostic{
@@ -253,9 +247,30 @@ func resourcemimirRuleGroupRecordingDelete(ctx context.Context, d *schema.Resour
 			fmt.Sprintf("%s%s", client.uri, path),
 			err))
 	}
+	// Retry read as mimir api could return a 200 status code but the rule group still exist because of the event change notification propagation latency.
+	// Add delay of <ruleGroupReadDelayAfterChange> * time.Second) between each retry with a <ruleGroupReadRetryAfterChange> max retries.
+	for i := 1; i <= ruleGroupReadRetryAfterChange; i++ {
+		_, err := ruleGroupRecordingRead(meta, name, namespace)
+		if err == nil {
+			log.Printf("[WARN] Recording rule group previously deleted '%s' still exist (%d/3)", name, i)
+			time.Sleep(ruleGroupReadDelayAfterChangeDuration)
+			continue
+		} else if strings.Contains(err.Error(), "response code '404'") {
+			break
+		}
+		return diag.FromErr(err)
+	}
 	d.SetId("")
-
 	return diag.Diagnostics{}
+}
+
+func ruleGroupRecordingRead(meta interface{}, name, namespace string) (string, error) {
+	var headers map[string]string
+	client := meta.(*apiClient)
+	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	jobraw, err := client.sendRequest("ruler", "GET", path, "", headers)
+	baseMsg := fmt.Sprintf("Cannot read recording rule group '%s' (namespace: %s) -", name, namespace)
+	return jobraw, handleHTTPError(err, baseMsg)
 }
 
 func expandRecordingRules(v []interface{}) []recordingRule {


### PR DESCRIPTION
When recreating some resources, the API could return error  `resource already exists` just after deletion.

This can occurs when there is lot of change which trigger many event change notification in mimir.

To avoid doing another TF plan/apply to recreate missing resources, adding a check with a wait/retry to read the resource after a deletion.