### PR TITLE
Check the ID split to ensure that it includes both a namespace and a name

### DIFF
--- a/mimir/resource_mimir_rule_group_alerting.go
+++ b/mimir/resource_mimir_rule_group_alerting.go
@@ -163,6 +163,11 @@ func resourcemimirRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceD
 
 	// use id as read is also called by import
 	idArr := strings.Split(d.Id(), "/")
+
+	if len(idArr) != 2 {
+		return diag.FromErr(fmt.Errorf("invalid id format: expected 'namespace/name', got '%s'", d.Id()))
+	}
+
 	namespace := idArr[0]
 	name := idArr[1]
 

--- a/mimir/resource_mimir_rule_group_recording.go
+++ b/mimir/resource_mimir_rule_group_recording.go
@@ -164,6 +164,11 @@ func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resource
 
 	// use id as read is also called by import
 	idArr := strings.Split(d.Id(), "/")
+
+	if len(idArr) != 2 {
+		return diag.FromErr(fmt.Errorf("invalid id format: expected 'namespace/name', got '%s'", d.Id()))
+	}
+
 	namespace := idArr[0]
 	name := idArr[1]
 


### PR DESCRIPTION
When importing an alerting group or a recording group, it's easy to forget the namespace, which can lead to a panic


```bash
$ terraform import 'module.mimir_rules_pack["mimir_rules"].mimir_rule_group_recording.default' mimir_storage

Stack trace from the terraform-provider-mimir_v1.0.5 plugin:

panic: runtime error: index out of range [1] with length 1

goroutine 81 [running]:
github.com/fgouteroux/terraform-provider-mimir/mimir.resourcemimirRuleGroupRecordingRead({0x10103db60?, 0x14000928660?}, 0x1400090cf80, {0x100f1da80, 0x140008bc360})
	github.com/fgouteroux/terraform-provider-mimir/mimir/resource_mimir_rule_group_recording.go:168 +0xa3c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x140006c7c00, {0x10103db60, 0x14000928660}, 0x1400090cf80, {0x100f1da80, 0x140008bc360})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/resource.go:750 +0xe4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0x140006c7c00, {0x10103db60, 0x14000928660}, 0x140009105b0, {0x100f1da80, 0x140008bc360})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/resource.go:1044 +0x408
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0x1400063d5f0, {0x10103db60?, 0x140009285a0?}, 0x140009064c0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/grpc_provider.go:616 +0x3e4
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0x14000209220, {0x10103db60?, 0x14000903b90?}, 0x14000816660)
	github.com/hashicorp/terraform-plugin-go@v0.16.0/tfprotov5/tf5server/server.go:751 +0x394
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0x100ffbc40, 0x14000209220}, {0x10103db60, 0x14000903b90}, 0x1400090c980, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.16.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:386 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x1400064c000, {0x10103db60, 0x14000903b00}, {0x1010429a0, 0x14000174600}, 0x14000915200, 0x140006d2330, 0x10169bd90, 0x0)
	google.golang.org/grpc@v1.64.0/server.go:1379 +0xb58
google.golang.org/grpc.(*Server).handleStream(0x1400064c000, {0x1010429a0, 0x14000174600}, 0x14000915200)
	google.golang.org/grpc@v1.64.0/server.go:1790 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.64.0/server.go:1029 +0x8c
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 61
	google.golang.org/grpc@v1.64.0/server.go:1040 +0x13c

Error: The terraform-provider-mimir_v1.0.5 plugin crashed!
```

With this PR, instead of triggering a panic, we notify the user about a missing namespace and exit gracefully.