### PR TITLE
feat: add optional org_id parameter in resource/datasource level

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -9,7 +9,6 @@ min-occurrences = 5
 disable-all = true
 enable = [
   "dogsled",
-  "exportloopref",
   "goconst",
   "gocritic",
   "gocyclo",

--- a/docs/data-sources/alertmanager_config.md
+++ b/docs/data-sources/alertmanager_config.md
@@ -22,6 +22,7 @@ data "mimir_alertmanager_config" "mytenant" {}
 ### Optional
 
 - `name` (String) Name of the alertmanager configuration. Only used for resource dependency.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 
 ### Read-Only
 
@@ -887,7 +888,7 @@ Read-Only:
 
 - `api_url` (String)
 - `bot_token` (String)
-- `chat_id` (String)
+- `chat_id` (Number)
 - `disable_notifications` (Boolean)
 - `http_config` (List of Object) (see [below for nested schema](#nestedobjatt--receiver--telegram_configs--http_config))
 - `message` (String)

--- a/docs/data-sources/distributor_tenant_stats.md
+++ b/docs/data-sources/distributor_tenant_stats.md
@@ -21,6 +21,7 @@ data "mimir_distributor_tenant_stats" "tenants" {}
 
 ### Optional
 
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `user` (String) Query specific user stats, if not specified, all users are returned
 
 ### Read-Only

--- a/docs/data-sources/rule_group_alerting.md
+++ b/docs/data-sources/rule_group_alerting.md
@@ -29,6 +29,7 @@ data "mimir_rule_group_alerting" "alert" {
 ### Optional
 
 - `namespace` (String) Alerting Rule group namespace
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 
 ### Read-Only
 

--- a/docs/data-sources/rule_group_recording.md
+++ b/docs/data-sources/rule_group_recording.md
@@ -29,6 +29,7 @@ data "mimir_rule_group_recording" "record" {
 ### Optional
 
 - `namespace` (String) Recording Rule group namespace
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 
 ### Read-Only
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ provider "mimir" {
 
 ### Required
 
-- `org_id` (String) The organization id to operate on within mimir.
+- `org_id` (String) The default organization id to operate on within mimir. For resources that have an org_id attribute, the resource-level attribute has priority. May alternatively be set via the MIMIR_ORG_ID environment variable.
 
 ### Optional
 

--- a/docs/resources/alertmanager_config.md
+++ b/docs/resources/alertmanager_config.md
@@ -67,6 +67,7 @@ resource "mimir_alertmanager_config" "mytenant" {
 
 - `global` (Block List, Max: 1) (see [below for nested schema](#nestedblock--global))
 - `inhibit_rule` (Block List) Mutes an alert (target) matching a set of matchers when an alert (source) exists that matches another set of matchers. (see [below for nested schema](#nestedblock--inhibit_rule))
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `templates` (List of String) A list of template names to use.
 - `templates_files` (Map of String) A map of key values string, where the key is the template name and the value the content of the template.
 - `time_interval` (Block List) A list of time intervals for muting/activating routes. (see [below for nested schema](#nestedblock--time_interval))
@@ -828,7 +829,7 @@ Optional:
 
 - `api_url` (String) The Telegram API URL. If not specified, default API URL will be used.
 - `bot_token` (String, Sensitive) Telegram bot token
-- `chat_id` (String) ID of the chat where to send the messages.
+- `chat_id` (Number) ID of the chat where to send the messages.
 - `disable_notifications` (Boolean) Disable telegram notifications
 - `http_config` (Block List, Max: 1) The HTTP client's configuration. (see [below for nested schema](#nestedblock--receiver--telegram_configs--http_config))
 - `message` (String) Message template

--- a/docs/resources/rule_group_alerting.md
+++ b/docs/resources/rule_group_alerting.md
@@ -42,6 +42,7 @@ resource "mimir_rule_group_alerting" "test" {
 
 - `interval` (String) Alerting Rule group interval
 - `namespace` (String) Alerting Rule group namespace
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `source_tenants` (List of String) Allows aggregating data from multiple tenants while evaluating a rule group.
 
 ### Read-Only

--- a/docs/resources/rule_group_recording.md
+++ b/docs/resources/rule_group_recording.md
@@ -38,6 +38,7 @@ resource "mimir_rule_group_recording" "test" {
 - `evaluation_delay` (String, Deprecated) **Deprecated** The duration by which to delay the execution of the recording rule.
 - `interval` (String) Recording Rule group interval
 - `namespace` (String) Recording Rule group namespace
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `query_offset` (String) The duration by which to delay the execution of the recording rule.
 - `source_tenants` (List of String) Allows aggregating data from multiple tenants while evaluating a rule group.
 

--- a/mimir/data_source_mimir_alertmanager_config.go
+++ b/mimir/data_source_mimir_alertmanager_config.go
@@ -19,7 +19,13 @@ func dataSourcemimirAlertmanagerConfig() *schema.Resource {
 func dataSourcemimirAlertmanagerConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*apiClient)
 	name := d.Get("name").(string)
-	resp, err := client.sendRequest("alertmanager", "GET", apiAlertsPath, "", make(map[string]string))
+	orgID := d.Get("org_id").(string)
+
+	headers := make(map[string]string)
+	if orgID != "" {
+		headers["X-Scope-OrgID"] = orgID
+	}
+	resp, err := client.sendRequest("alertmanager", "GET", apiAlertsPath, "", headers)
 	baseMsg := "Cannot read alertmanager config"
 	err = handleHTTPError(err, baseMsg)
 	if err != nil {

--- a/mimir/data_source_mimir_alertmanager_config_test.go
+++ b/mimir/data_source_mimir_alertmanager_config_test.go
@@ -36,3 +36,41 @@ var testAccDataSourceAlertmanagerConfig_basic = fmt.Sprintf(`
 		name = "${mimir_alertmanager_config.mytenant.id}"
 	}
 `, testAccResourceAlertmanagerConfig_basic)
+
+func TestAccDataSourceAlertmanagerConfig_WithOrgID(t *testing.T) {
+	// Init client
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirAlertmanagerConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAlertmanagerConfig_WithOrgID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirAlertmanagerConfigExists("mimir_alertmanager_config.another_tenant", client),
+					resource.TestCheckResourceAttr("mimir_alertmanager_config.another_tenant", "org_id", "another_tenant"),
+					resource.TestCheckResourceAttr("mimir_alertmanager_config.another_tenant", "route.0.group_by.0", "..."),
+					resource.TestCheckResourceAttr("mimir_alertmanager_config.another_tenant", "route.0.group_wait", "30s"),
+					resource.TestCheckResourceAttr("mimir_alertmanager_config.another_tenant", "route.0.group_interval", "5m"),
+					resource.TestCheckResourceAttr("mimir_alertmanager_config.another_tenant", "route.0.repeat_interval", "1h"),
+					resource.TestCheckResourceAttr("mimir_alertmanager_config.another_tenant", "route.0.receiver", "test"),
+					resource.TestCheckResourceAttr("mimir_alertmanager_config.another_tenant", "receiver.0.name", "test"),
+				),
+			},
+		},
+	})
+}
+
+var testAccDataSourceAlertmanagerConfig_WithOrgID = fmt.Sprintf(`
+	%s
+
+	data "mimir_alertmanager_config" "another_tenant" {
+		org_id = "another_tenant"
+		name = "${mimir_alertmanager_config.another_tenant.id}"
+	}
+`, testAccResourceAlertmanagerConfig_WithOrgID)

--- a/mimir/data_source_mimir_distributor_tenant_stats.go
+++ b/mimir/data_source_mimir_distributor_tenant_stats.go
@@ -29,7 +29,7 @@ func dataSourcemimirDistributorTenantStats() *schema.Resource {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The organization id to operate on within mimir.",
+				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
 			},
 			"user": {
 				Type:        schema.TypeString,

--- a/mimir/data_source_mimir_distributor_tenant_stats.go
+++ b/mimir/data_source_mimir_distributor_tenant_stats.go
@@ -25,6 +25,12 @@ func dataSourcemimirDistributorTenantStats() *schema.Resource {
 		ReadContext: dataSourcemimirDistributorTenantStatsRead,
 
 		Schema: map[string]*schema.Schema{
+			"org_id": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Description: "The organization id to operate on within mimir.",
+			},
 			"user": {
 				Type:        schema.TypeString,
 				Description: "Query specific user stats, if not specified, all users are returned",
@@ -68,8 +74,13 @@ func dataSourcemimirDistributorTenantStats() *schema.Resource {
 func dataSourcemimirDistributorTenantStatsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*apiClient)
 	user := d.Get("user").(string)
+	orgID := d.Get("org_id").(string)
 
 	headers := map[string]string{"Accept": "json"}
+	if orgID != "" {
+		headers["X-Scope-OrgID"] = orgID
+	}
+
 	jobraw, err := client.sendRequest("distributor", "GET", "/all_user_stats", "", headers)
 
 	baseMsg := "Cannot read user stats"

--- a/mimir/data_source_mimir_rule_group_alerting.go
+++ b/mimir/data_source_mimir_rule_group_alerting.go
@@ -19,7 +19,7 @@ func dataSourcemimirRuleGroupAlerting() *schema.Resource {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The organization id to operate on within mimir.",
+				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
 			},
 			"namespace": {
 				Type:        schema.TypeString,

--- a/mimir/data_source_mimir_rule_group_alerting_test.go
+++ b/mimir/data_source_mimir_rule_group_alerting_test.go
@@ -31,3 +31,30 @@ var testAccDataSourceRuleGroupAlerting_basic = fmt.Sprintf(`
 		namespace = "${mimir_rule_group_alerting.alert_1.namespace}"
 	}
 `, testAccResourceRuleGroupAlerting_basic)
+
+func TestAccDataSourceRuleGroupAlerting_withOrgID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRuleGroupAlerting_withOrgID,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.mimir_rule_group_alerting.alert_1_withOrgID", "org_id", "another_tenant"),
+					resource.TestCheckResourceAttr("data.mimir_rule_group_alerting.alert_1_withOrgID", "name", "alert_1_withOrgID"),
+					resource.TestCheckResourceAttr("data.mimir_rule_group_alerting.alert_1_withOrgID", "namespace", "namespace_1"),
+				),
+			},
+		},
+	})
+}
+
+var testAccDataSourceRuleGroupAlerting_withOrgID = fmt.Sprintf(`
+	%s
+
+	data "mimir_rule_group_alerting" "alert_1_withOrgID" {
+		org_id = "${mimir_rule_group_alerting.alert_1_withOrgID.org_id}"
+		name = "${mimir_rule_group_alerting.alert_1_withOrgID.name}"
+		namespace = "${mimir_rule_group_alerting.alert_1_withOrgID.namespace}"
+	}
+`, testAccResourceRuleGroupAlerting_withOrgID)

--- a/mimir/data_source_mimir_rule_group_recording.go
+++ b/mimir/data_source_mimir_rule_group_recording.go
@@ -19,7 +19,7 @@ func dataSourcemimirRuleGroupRecording() *schema.Resource {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The organization id to operate on within mimir.",
+				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
 			},
 			"namespace": {
 				Type:        schema.TypeString,

--- a/mimir/data_source_mimir_rule_group_recording_test.go
+++ b/mimir/data_source_mimir_rule_group_recording_test.go
@@ -31,3 +31,30 @@ var testAccDataSourceRuleGroupRecording_basic = fmt.Sprintf(`
 		namespace = "${mimir_rule_group_recording.record_1.namespace}"
 	}
 `, testAccResourceRuleGroupRecording_basic)
+
+func TestAccDataSourceRuleGroupRecording_withOrgID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRuleGroupRecording_withOrgID,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.mimir_rule_group_recording.record_1_withOrgID", "org_id", "another_tenant"),
+					resource.TestCheckResourceAttr("data.mimir_rule_group_recording.record_1_withOrgID", "name", "record_1_withOrgID"),
+					resource.TestCheckResourceAttr("data.mimir_rule_group_recording.record_1_withOrgID", "namespace", "namespace_1"),
+				),
+			},
+		},
+	})
+}
+
+var testAccDataSourceRuleGroupRecording_withOrgID = fmt.Sprintf(`
+	%s
+
+	data "mimir_rule_group_recording" "record_1_withOrgID" {
+		org_id = "${mimir_rule_group_recording.record_1_withOrgID.org_id}"
+		name = "${mimir_rule_group_recording.record_1_withOrgID.name}"
+		namespace = "${mimir_rule_group_recording.record_1_withOrgID.namespace}"
+	}
+`, testAccResourceRuleGroupRecording_withOrgID)

--- a/mimir/provider.go
+++ b/mimir/provider.go
@@ -53,7 +53,7 @@ func Provider(version string) func() *schema.Provider {
 					Type:        schema.TypeString,
 					Required:    true,
 					DefaultFunc: schema.EnvDefaultFunc("MIMIR_ORG_ID", nil),
-					Description: "The organization id to operate on within mimir.",
+					Description: "The default organization id to operate on within mimir. For resources that have an org_id attribute, the resource-level attribute has priority. May alternatively be set via the MIMIR_ORG_ID environment variable.",
 				},
 				"token": {
 					Type:        schema.TypeString,

--- a/mimir/provider.go
+++ b/mimir/provider.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var (
@@ -51,11 +50,10 @@ func Provider(version string) func() *schema.Provider {
 					Description: "mimir distributor base url",
 				},
 				"org_id": {
-					Type:         schema.TypeString,
-					Required:     true,
-					DefaultFunc:  schema.EnvDefaultFunc("MIMIR_ORG_ID", nil),
-					Description:  "The organization id to operate on within mimir.",
-					ValidateFunc: validation.StringIsNotEmpty,
+					Type:        schema.TypeString,
+					Required:    true,
+					DefaultFunc: schema.EnvDefaultFunc("MIMIR_ORG_ID", nil),
+					Description: "The organization id to operate on within mimir.",
 				},
 				"token": {
 					Type:        schema.TypeString,
@@ -195,7 +193,10 @@ func providerConfigure(version string, p *schema.Provider, d *schema.ResourceDat
 			headers[k] = v.(string)
 		}
 	}
-	headers["X-Scope-OrgID"] = d.Get("org_id").(string)
+	orgID := d.Get("org_id").(string)
+	if orgID != "" {
+		headers["X-Scope-OrgID"] = orgID
+	}
 	headers["User-Agent"] = p.UserAgent("terraform-provider-mimir", version)
 
 	opt := &apiClientOpt{

--- a/mimir/resource_mimir_rule_group_alerting.go
+++ b/mimir/resource_mimir_rule_group_alerting.go
@@ -26,7 +26,7 @@ func resourcemimirRuleGroupAlerting() *schema.Resource {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The organization id to operate on within mimir.",
+				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
 			},
 			"namespace": {
 				Type:        schema.TypeString,

--- a/mimir/resource_mimir_rule_group_alerting.go
+++ b/mimir/resource_mimir_rule_group_alerting.go
@@ -22,6 +22,12 @@ func resourcemimirRuleGroupAlerting() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
+			"org_id": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Description: "The organization id to operate on within mimir.",
+			},
 			"namespace": {
 				Type:        schema.TypeString,
 				Description: "Alerting Rule group namespace",
@@ -105,12 +111,17 @@ func resourcemimirRuleGroupAlertingCreate(ctx context.Context, d *schema.Resourc
 	client := meta.(*apiClient)
 	name := d.Get("name").(string)
 	namespace := d.Get("namespace").(string)
+	orgID := d.Get("org_id").(string)
 
 	if !overwriteRuleGroupConfig {
 		ruleGroupConfigExists := true
 
 		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
-		_, err := client.sendRequest("ruler", "GET", path, "", make(map[string]string))
+		headers := make(map[string]string)
+		if orgID != "" {
+			headers["X-Scope-OrgID"] = orgID
+		}
+		_, err := client.sendRequest("ruler", "GET", path, "", headers)
 		baseMsg := fmt.Sprintf("Cannot create alerting rule group '%s' (namespace: %s) -", name, namespace)
 		err = handleHTTPError(err, baseMsg)
 		if err != nil {
@@ -134,6 +145,9 @@ func resourcemimirRuleGroupAlertingCreate(ctx context.Context, d *schema.Resourc
 	}
 	data, _ := yaml.Marshal(rules)
 	headers := map[string]string{"Content-Type": "application/yaml"}
+	if orgID != "" {
+		headers["X-Scope-OrgID"] = orgID
+	}
 
 	path := fmt.Sprintf("/config/v1/rules/%s", namespace)
 	_, err := client.sendRequest("ruler", "POST", path, string(data), headers)
@@ -142,7 +156,11 @@ func resourcemimirRuleGroupAlertingCreate(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(fmt.Sprintf("%s/%s", namespace, name))
+	if orgID != "" {
+		d.SetId(fmt.Sprintf("%s/%s/%s", orgID, namespace, name))
+	} else {
+		d.SetId(fmt.Sprintf("%s/%s", namespace, name))
+	}
 
 	// Retry read as mimir api could return a 404 status code caused by the event change notification propagation.
 	// Add delay of <ruleGroupReadDelayAfterChange> * time.Second) between each retry with a <ruleGroupReadRetryAfterChange> max retries.
@@ -164,14 +182,21 @@ func resourcemimirRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceD
 	// use id as read is also called by import
 	idArr := strings.Split(d.Id(), "/")
 
-	if len(idArr) != 2 {
-		return diag.FromErr(fmt.Errorf("invalid id format: expected 'namespace/name', got '%s'", d.Id()))
+	var name, namespace, orgID string
+
+	switch len(idArr) {
+	case 2:
+		namespace = idArr[0]
+		name = idArr[1]
+	case 3:
+		orgID = idArr[0]
+		namespace = idArr[1]
+		name = idArr[2]
+	default:
+		return diag.FromErr(fmt.Errorf("invalid id format: expected 'namespace/name' or 'org_id/namespace/name', got '%s'", d.Id()))
 	}
 
-	namespace := idArr[0]
-	name := idArr[1]
-
-	jobraw, err := ruleGroupAlertingRead(meta, name, namespace)
+	jobraw, err := ruleGroupAlertingRead(meta, name, namespace, orgID)
 	if err != nil {
 		if d.IsNewResource() && strings.Contains(err.Error(), "response code '404'") {
 			diags = append(diags, diag.Diagnostic{
@@ -200,6 +225,10 @@ func resourcemimirRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
+	err = d.Set("org_id", orgID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	err = d.Set("namespace", namespace)
 	if err != nil {
 		return diag.FromErr(err)
@@ -225,6 +254,7 @@ func resourcemimirRuleGroupAlertingUpdate(ctx context.Context, d *schema.Resourc
 		client := meta.(*apiClient)
 		name := d.Get("name").(string)
 		namespace := d.Get("namespace").(string)
+		orgID := d.Get("org_id").(string)
 
 		rules := &alertingRuleGroup{
 			Name:          name,
@@ -234,6 +264,9 @@ func resourcemimirRuleGroupAlertingUpdate(ctx context.Context, d *schema.Resourc
 		}
 		data, _ := yaml.Marshal(rules)
 		headers := map[string]string{"Content-Type": "application/yaml"}
+		if orgID != "" {
+			headers["X-Scope-OrgID"] = orgID
+		}
 
 		path := fmt.Sprintf("/config/v1/rules/%s", namespace)
 		_, err := client.sendRequest("ruler", "POST", path, string(data), headers)
@@ -253,7 +286,12 @@ func resourcemimirRuleGroupAlertingDelete(ctx context.Context, d *schema.Resourc
 	client := meta.(*apiClient)
 	name := d.Get("name").(string)
 	namespace := d.Get("namespace").(string)
-	var headers map[string]string
+	orgID := d.Get("org_id").(string)
+
+	headers := make(map[string]string)
+	if orgID != "" {
+		headers["X-Scope-OrgID"] = orgID
+	}
 	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
 	_, err := client.sendRequest("ruler", "DELETE", path, "", headers)
 	if err != nil {
@@ -266,7 +304,7 @@ func resourcemimirRuleGroupAlertingDelete(ctx context.Context, d *schema.Resourc
 	// Retry read as mimir api could return a 200 status code but the rule group still exist because of the event change notification propagation latency.
 	// Add delay of <ruleGroupReadDelayAfterChange> * time.Second) between each retry with a <ruleGroupReadRetryAfterChange> max retries.
 	for i := 1; i <= ruleGroupReadRetryAfterChange; i++ {
-		_, err := ruleGroupAlertingRead(meta, name, namespace)
+		_, err := ruleGroupAlertingRead(meta, name, namespace, orgID)
 		if err == nil {
 			log.Printf("[WARN] Alerting rule group previously deleted '%s' still exist (%d/3)", name, i)
 			time.Sleep(ruleGroupReadDelayAfterChangeDuration)
@@ -280,8 +318,11 @@ func resourcemimirRuleGroupAlertingDelete(ctx context.Context, d *schema.Resourc
 	return diag.Diagnostics{}
 }
 
-func ruleGroupAlertingRead(meta interface{}, name, namespace string) (string, error) {
-	var headers map[string]string
+func ruleGroupAlertingRead(meta interface{}, name, namespace, orgID string) (string, error) {
+	headers := make(map[string]string)
+	if orgID != "" {
+		headers["X-Scope-OrgID"] = orgID
+	}
 	client := meta.(*apiClient)
 	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
 	jobraw, err := client.sendRequest("ruler", "GET", path, "", headers)

--- a/mimir/resource_mimir_rule_group_alerting_test.go
+++ b/mimir/resource_mimir_rule_group_alerting_test.go
@@ -44,76 +44,76 @@ func TestAccResourceRuleGroupAlerting_expectValidationError(t *testing.T) {
 }
 
 const testAccResourceRuleGroupAlerting_expectNameValidationError = `
-	resource "mimir_rule_group_alerting" "alert_1" {
-		name = "alert-@error" 
-		namespace = "namespace_1"
-		rule {
-			alert = "test1_alert"
-			expr   = "test1_metric"
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1" {
+        name = "alert-@error" 
+        namespace = "namespace_1"
+        rule {
+            alert = "test1_alert"
+            expr   = "test1_metric"
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_expectRuleNameValidationError = `
-	resource "mimir_rule_group_alerting" "alert_1" {
-		name = "alert_1"
-		namespace = "namespace_1"
-		rule {
-			alert = "test1 alert"
-			expr   = "test1_metric"
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1" {
+        name = "alert_1"
+        namespace = "namespace_1"
+        rule {
+            alert = "test1 alert"
+            expr   = "test1_metric"
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_expectPromQLValidationError = `
-	resource "mimir_rule_group_alerting" "alert_1" {
-		name = "alert_1"
-		namespace = "namespace_1"
-		rule {
-			alert = "test1_alert"
-			expr   = "rate(hi)"
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1" {
+        name = "alert_1"
+        namespace = "namespace_1"
+        rule {
+            alert = "test1_alert"
+            expr   = "rate(hi)"
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_expectDurationValidationError = `
-	resource "mimir_rule_group_alerting" "alert_1" {
-		name = "alert_1"
-		namespace = "namespace_1"
-		rule {
-			alert = "test1_alert"
-			expr  = "test1_metric"
-			for   = "3months"
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1" {
+        name = "alert_1"
+        namespace = "namespace_1"
+        rule {
+            alert = "test1_alert"
+            expr  = "test1_metric"
+            for   = "3months"
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_expectLabelNameValidationError = `
-	resource "mimir_rule_group_alerting" "alert_1" {
-		name = "alert_1"
-		namespace = "namespace_1"
-		rule {
-			alert = "test1_alert"
-			expr   = "test1_metric"
-			labels = {
-				 ins-tance = "localhost"
-			}
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1" {
+        name = "alert_1"
+        namespace = "namespace_1"
+        rule {
+            alert = "test1_alert"
+            expr   = "test1_metric"
+            labels = {
+                 ins-tance = "localhost"
+            }
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_expectAnnotationNameValidationError = `
-	resource "mimir_rule_group_alerting" "alert_1" {
-		name = "alert_1"
-		namespace = "namespace_1"
-		rule {
-			alert = "test1_alert"
-			expr   = "test1_metric"
-			annotations = {
-				 ins-tance = "localhost"
-			}
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1" {
+        name = "alert_1"
+        namespace = "namespace_1"
+        rule {
+            alert = "test1_alert"
+            expr   = "test1_metric"
+            annotations = {
+                 ins-tance = "localhost"
+            }
+        }
+    }
 `
 
 func TestAccResourceRuleGroupAlerting_Basic(t *testing.T) {
@@ -240,18 +240,18 @@ func TestAccResourceRuleGroupAlerting_Federated(t *testing.T) {
 func TestAccResourceRuleGroupAlerting_PromQLValidation_HistogramAvg(t *testing.T) {
 	/* Skip this test if mimir version is older than 2.12.0
 
-	=== RUN   TestAccResourceRuleGroupAlerting_PromQLValidation_HistogramAvg
-		resource_mimir_rule_group_alerting_test.go:245: Step 1/1 error: Error running apply: exit status 1
-			2024/07/05 09:20:03 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.18.1
+	   === RUN   TestAccResourceRuleGroupAlerting_PromQLValidation_HistogramAvg
+	       resource_mimir_rule_group_alerting_test.go:245: Step 1/1 error: Error running apply: exit status 1
+	           2024/07/05 09:20:03 [DEBUG] Using modified User-Agent: Terraform/0.12.31 HashiCorp-terraform-exec/0.18.1
 
-			Error: Cannot create alerting rule group 'alert_1_histogram_avg_rule_group' (namespace: namespace_1) - unexpected response code '400': 4:13: group "alert_1_histogram_avg_rule_group", rule 0, "test_histogram_avg": could not parse expression: 1:1: parse error: unknown function with name "histogram_avg"
-
-
-			on terraform_plugin_test.tf line 2, in resource "mimir_rule_group_alerting" "alert_1_histogram_avg_rule_group":
-			2: 	resource "mimir_rule_group_alerting" "alert_1_histogram_avg_rule_group" {
+	           Error: Cannot create alerting rule group 'alert_1_histogram_avg_rule_group' (namespace: namespace_1) - unexpected response code '400': 4:13: group "alert_1_histogram_avg_rule_group", rule 0, "test_histogram_avg": could not parse expression: 1:1: parse error: unknown function with name "histogram_avg"
 
 
-	--- FAIL: TestAccResourceRuleGroupAlerting_PromQLValidation_HistogramAvg (0.28s)
+	           on terraform_plugin_test.tf line 2, in resource "mimir_rule_group_alerting" "alert_1_histogram_avg_rule_group":
+	           2:  resource "mimir_rule_group_alerting" "alert_1_histogram_avg_rule_group" {
+
+
+	   --- FAIL: TestAccResourceRuleGroupAlerting_PromQLValidation_HistogramAvg (0.28s)
 
 	*/
 	currentVersion, _ := version.NewVersion(os.Getenv("MIMIR_VERSION"))
@@ -314,43 +314,69 @@ func TestAccResourceRuleGroupAlerting_FormatPromQLExpr(t *testing.T) {
 	os.Setenv("MIMIR_FORMAT_PROMQL_EXPR", "false")
 }
 
-const testAccResourceRuleGroupAlerting_basic = `
-	resource "mimir_rule_group_alerting" "alert_1" {
-		name = "alert_1"
-		namespace = "namespace_1"
-		rule {
-			alert = "test1"
-			expr  = "test1_metric"
-		}
-		rule {
-			alert = "test2"
-			expr   = "test2_metric"
-			for    = "0s"
-		}
+func TestAccResourceRuleGroupAlerting_WithOrgID(t *testing.T) {
+	// Init client
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
 	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceRuleGroupAlerting_withOrgID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.alert_1_withOrgID", "alert_1_withOrgID", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_withOrgID", "org_id", "another_tenant"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_withOrgID", "name", "alert_1_withOrgID"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_withOrgID", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_withOrgID", "rule.0.alert", "test1_info"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.alert_1_withOrgID", "rule.0.expr", "test1_metric"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceRuleGroupAlerting_basic = `
+    resource "mimir_rule_group_alerting" "alert_1" {
+        name = "alert_1"
+        namespace = "namespace_1"
+        rule {
+            alert = "test1"
+            expr  = "test1_metric"
+        }
+        rule {
+            alert = "test2"
+            expr   = "test2_metric"
+            for    = "0s"
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_basic_update = `
-	resource "mimir_rule_group_alerting" "alert_1" {
-		name = "alert_1"
-		namespace = "namespace_1"
-		rule {
-			alert = "test1"
-			expr  = "test1_metric"
-		}
-		rule {
-			alert = "test2"
-			expr   = "test2_metric"
-			for = "1m"
-			labels = {
-				severity = "critical"
-			}
-			annotations = {
-				summary = "test 2 alert summary"
-				description = "test 2 alert description"
-			}
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1" {
+        name = "alert_1"
+        namespace = "namespace_1"
+        rule {
+            alert = "test1"
+            expr  = "test1_metric"
+        }
+        rule {
+            alert = "test2"
+            expr   = "test2_metric"
+            for = "1m"
+            labels = {
+                severity = "critical"
+            }
+            annotations = {
+                summary = "test 2 alert summary"
+                description = "test 2 alert description"
+            }
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_interval = `
@@ -378,59 +404,71 @@ const testAccResourceRuleGroupAlerting_interval_update = `
 `
 
 const testAccResourceRuleGroupAlerting_prettify_promql_expr = `
-	resource "mimir_rule_group_alerting" "alert_1_prettify" {
-		name = "alert_1_prettify"
-		namespace = "namespace_1"
-		rule {
-			alert = "checkPrettifyPromQL"
-			expr  = "up==0 unless my_very_very_long_useless_metric_that_mean_nothing_but_necessary_to_check_prettify_promql > 300"
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1_prettify" {
+        name = "alert_1_prettify"
+        namespace = "namespace_1"
+        rule {
+            alert = "checkPrettifyPromQL"
+            expr  = "up==0 unless my_very_very_long_useless_metric_that_mean_nothing_but_necessary_to_check_prettify_promql > 300"
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_federated_rule_group = `
-	resource "mimir_rule_group_alerting" "alert_1_federated_rule_group" {
-		name = "alert_1_federated_rule_group"
-		source_tenants = ["tenant-a", "tenant-b"]
-		namespace = "namespace_1"
-		rule {
-			alert = "test1"
-			expr  = "test1_metric"
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1_federated_rule_group" {
+        name = "alert_1_federated_rule_group"
+        source_tenants = ["tenant-a", "tenant-b"]
+        namespace = "namespace_1"
+        rule {
+            alert = "test1"
+            expr  = "test1_metric"
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_federated_rule_group_tenant_change = `
-	resource "mimir_rule_group_alerting" "alert_1_federated_rule_group" {
-		name = "alert_1_federated_rule_group"
-		source_tenants = ["tenant-a", "tenant-c", "tenant-d"]
-		namespace = "namespace_1"
-		rule {
-			alert = "test1"
-			expr  = "test1_metric"
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1_federated_rule_group" {
+        name = "alert_1_federated_rule_group"
+        source_tenants = ["tenant-a", "tenant-c", "tenant-d"]
+        namespace = "namespace_1"
+        rule {
+            alert = "test1"
+            expr  = "test1_metric"
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_federated_rule_group_rule_change = `
-	resource "mimir_rule_group_alerting" "alert_1_federated_rule_group" {
-		name = "alert_1_federated_rule_group"
-		source_tenants = ["tenant-a", "tenant-c", "tenant-d"]
-		namespace = "namespace_1"
-		rule {
-			alert = "test2"
-			expr  = "test2_metric"
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1_federated_rule_group" {
+        name = "alert_1_federated_rule_group"
+        source_tenants = ["tenant-a", "tenant-c", "tenant-d"]
+        namespace = "namespace_1"
+        rule {
+            alert = "test2"
+            expr  = "test2_metric"
+        }
+    }
 `
 
 const testAccResourceRuleGroupAlerting_promql_validation_histogram_avg = `
-	resource "mimir_rule_group_alerting" "alert_1_histogram_avg_rule_group" {
-		name = "alert_1_histogram_avg_rule_group"
-		namespace = "namespace_1"
-		rule {
-			alert = "test_histogram_avg"
-			expr  = "histogram_avg(rate(test_metric[5m])) > 1"
-		}
-	}
+    resource "mimir_rule_group_alerting" "alert_1_histogram_avg_rule_group" {
+        name = "alert_1_histogram_avg_rule_group"
+        namespace = "namespace_1"
+        rule {
+            alert = "test_histogram_avg"
+            expr  = "histogram_avg(rate(test_metric[5m])) > 1"
+        }
+    }
+`
+
+const testAccResourceRuleGroupAlerting_withOrgID = `
+    resource "mimir_rule_group_alerting" "alert_1_withOrgID" {
+            org_id = "another_tenant"
+            name = "alert_1_withOrgID"
+            namespace = "namespace_1"
+            rule {
+                alert = "test1_info"
+                expr  = "test1_metric"
+            }
+    }
 `

--- a/mimir/resource_mimir_rule_group_recording.go
+++ b/mimir/resource_mimir_rule_group_recording.go
@@ -26,7 +26,7 @@ func resourcemimirRuleGroupRecording() *schema.Resource {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The organization id to operate on within mimir.",
+				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
 			},
 			"namespace": {
 				Type:        schema.TypeString,

--- a/mimir/resource_mimir_rule_group_recording_test.go
+++ b/mimir/resource_mimir_rule_group_recording_test.go
@@ -285,6 +285,32 @@ func TestAccResourceRuleGroupRecording_Federated(t *testing.T) {
 	})
 }
 
+func TestAccResourceRuleGroupRecording_WithOrgID(t *testing.T) {
+	// Init client
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceRuleGroupRecording_withOrgID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.record_1_withOrgID", "record_1_withOrgID", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_withOrgID", "org_id", "another_tenant"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_withOrgID", "name", "record_1_withOrgID"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_withOrgID", "namespace", "namespace_1"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_withOrgID", "rule.0.record", "test1_info"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.record_1_withOrgID", "rule.0.expr", "test1_metric"),
+				),
+			},
+		},
+	})
+}
+
 const testAccResourceRuleGroupRecording_basic = `
 	resource "mimir_rule_group_recording" "record_1" {
 		name = "record_1"
@@ -418,6 +444,18 @@ const testAccResourceRuleGroupRecording_query_offset_update = `
             rule {
                     record = "test1_info"
                     expr   = "test1_metric"
+            }
+    }
+`
+
+const testAccResourceRuleGroupRecording_withOrgID = `
+    resource "mimir_rule_group_recording" "record_1_withOrgID" {
+            org_id = "another_tenant"
+            name = "record_1_withOrgID"
+            namespace = "namespace_1"
+            rule {
+                record = "test1_info"
+                expr  = "test1_metric"
             }
     }
 `

--- a/mimir/schema_alertmanager_config.go
+++ b/mimir/schema_alertmanager_config.go
@@ -1280,7 +1280,7 @@ func resourceMimirAlertmanagerConfigSchemaV1() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			ForceNew:    true,
 			Optional:    true,
-			Description: "The organization id to operate on within mimir.",
+			Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
 		},
 		"global": {
 			Type:     schema.TypeList,
@@ -1719,7 +1719,7 @@ func dataSourceMimirAlertmanagerConfigSchemaV1() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			ForceNew:    true,
 			Optional:    true,
-			Description: "The organization id to operate on within mimir.",
+			Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
 		},
 		"name": {
 			Type:        schema.TypeString,

--- a/mimir/schema_alertmanager_config.go
+++ b/mimir/schema_alertmanager_config.go
@@ -1715,6 +1715,12 @@ func resourceMimirAlertmanagerConfigSchemaV1() map[string]*schema.Schema {
 
 func dataSourceMimirAlertmanagerConfigSchemaV1() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"org_id": {
+			Type:        schema.TypeString,
+			ForceNew:    true,
+			Optional:    true,
+			Description: "The organization id to operate on within mimir.",
+		},
 		"name": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/mimir/schema_alertmanager_config.go
+++ b/mimir/schema_alertmanager_config.go
@@ -1276,6 +1276,12 @@ func snsConfigFields() map[string]*schema.Schema {
 
 func resourceMimirAlertmanagerConfigSchemaV1() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"org_id": {
+			Type:        schema.TypeString,
+			ForceNew:    true,
+			Optional:    true,
+			Description: "The organization id to operate on within mimir.",
+		},
 		"global": {
 			Type:     schema.TypeList,
 			Optional: true,

--- a/mimir/shared_test.go
+++ b/mimir/shared_test.go
@@ -33,9 +33,16 @@ func testAccCheckMimirRuleGroupExists(n string, name string, client *apiClient) 
 			return fmt.Errorf("mimir object name %s not set in terraform", name)
 		}
 
+		orgID := rs.Primary.Attributes["org_id"]
+		name := rs.Primary.Attributes["name"]
+		namespace := rs.Primary.Attributes["namespace"]
+
 		/* Make a throw-away API object to read from the API */
-		var headers map[string]string
-		path := fmt.Sprintf("/config/v1/rules/%s", rs.Primary.ID)
+		headers := make(map[string]string)
+		if orgID != "" {
+			headers["X-Scope-OrgID"] = orgID
+		}
+		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
 		_, err := client.sendRequest("ruler", "GET", path, "", headers)
 		if err != nil {
 			return err
@@ -56,8 +63,15 @@ func testAccCheckMimirRuleGroupDestroy(s *terraform.State) error {
 			continue
 		}
 
-		var headers map[string]string
-		path := fmt.Sprintf("/config/v1/rules/%s", rs.Primary.ID)
+		orgID := rs.Primary.Attributes["org_id"]
+		name := rs.Primary.Attributes["name"]
+		namespace := rs.Primary.Attributes["namespace"]
+
+		headers := make(map[string]string)
+		if orgID != "" {
+			headers["X-Scope-OrgID"] = orgID
+		}
+		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
 		_, err := client.sendRequest("ruler", "GET", path, "", headers)
 
 		// If the error is equivalent to 404 not found, the widget is destroyed.


### PR DESCRIPTION
Add `org_id` parameter in resource/datasource, if not set use it from provider block.(https://github.com/fgouteroux/terraform-provider-mimir/issues/53)