### PR TITLE
Remove the check for provider URIs to allow dynamic provider configs

### DIFF
--- a/mimir/api_client.go
+++ b/mimir/api_client.go
@@ -51,7 +51,6 @@ type apiClient struct {
 
 // Make a new api client for RESTful calls
 func NewAPIClient(opt *apiClientOpt) (*apiClient, error) {
-
 	/* Remove any trailing slashes since we will append
 	   to this URL with our own root-prefixed location */
 	opt.uri = strings.TrimSuffix(opt.uri, "/")


### PR DESCRIPTION
When using this provider in a setup where e.g. the alertmanager is created from within terraform (e.g. the Scaleway alertmanager), you cannot use this provider to configure the alertmanager within the same terraform workspace. This is because the URI for the alertmanager is dynamic and taken from the result of the alertmanager creation on your cloud infrastructure. Setup of the alertmanager had to be done in a separate terraform workspace where the alertmanager URI is known from the start (and therefore the alertmanager already existed before the first 'plan' of the workspace).

To allow the creation of the alertmanager as well as the configuration of it within the same terraform workspace, I removed the static check in the provider setup. This will, of course, make the provider fail when the URI is not properly set. On the other hand it allows for the URI to be dynamically set during runtime of the provider. Also it is the same behavior as the loki provider has.