### PR TITLE
fix: use prometheus validation of 'for' time

### DIFF
--- a/mimir/resource_mimir_rules.go
+++ b/mimir/resource_mimir_rules.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v3"
 )
 
@@ -305,7 +306,7 @@ func validateRuleGroupsContent(ruleGroups RuleGroups) error {
 
 		// Validate interval if specified
 		if group.Interval != "" {
-			if _, err := time.ParseDuration(group.Interval); err != nil {
+			if _, err := model.ParseDuration(group.Interval); err != nil {
 				return fmt.Errorf("group %d (%s): invalid interval '%s': %v", i, group.Name, group.Interval, err)
 			}
 		}
@@ -352,7 +353,7 @@ func validateRule(rule Rule, groupIndex, ruleIndex int, groupName string) error 
 
 		// Validate 'for' duration if specified
 		if rule.For != "" {
-			if _, err := time.ParseDuration(rule.For); err != nil {
+			if _, err := model.ParseDuration(rule.For); err != nil {
 				return fmt.Errorf("group %d (%s), rule %d: invalid 'for' duration '%s': %v", groupIndex, groupName, ruleIndex, rule.For, err)
 			}
 		}

--- a/mimir/resource_mimir_rules_test.go
+++ b/mimir/resource_mimir_rules_test.go
@@ -8,6 +8,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func TestValidateRuleGroupsContent_AllowsPrometheusDurations(t *testing.T) {
+	ruleGroups := RuleGroups{
+		Groups: []RuleGroup{
+			{
+				Name:     "alert_group",
+				Interval: "1m",
+				Rules: []Rule{
+					{
+						Alert: "HighErrorRate",
+						Expr:  `rate(http_requests_total{status=~"5.."}[5m]) > 0`,
+						For:   "1d",
+					},
+				},
+			},
+		},
+	}
+
+	if err := validateRuleGroupsContent(ruleGroups); err != nil {
+		t.Fatalf("expected Prometheus-style durations to be valid, got: %v", err)
+	}
+}
+
 func TestAccResourceMimirRules_Basic(t *testing.T) {
 	// Init client
 	client, err := NewAPIClient(setupClient())


### PR DESCRIPTION
The current implementation uses `time.ParseDuration` whereas Prometheus/Alertmanger uses a modified `model.ParseDuration`. This allows additional time duration patterns such as `1d`, etc.