### PR TITLE
fix(mimir_rules): Update deletes removed rule groups from Mimir

### DIFF
--- a/mimir/resource_mimir_rules.go
+++ b/mimir/resource_mimir_rules.go
@@ -526,7 +526,14 @@ func resourceMimirRulesUpdate(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	oldManagedGroups := d.Get("managed_groups").([]interface{})
+	// Read the previous managed_groups from prior state, NOT via d.Get,
+	// because CustomizeDiff has already populated d.Get("managed_groups") with
+	// the new planned value via diff.SetNew. Using d.Get here makes
+	// oldManagedGroups equal to newManagedGroups, so groupsToDelete is always
+	// empty and groups removed from the YAML are never deleted from Mimir
+	// (they become orphaned, "unmanaged" rule groups).
+	oldManagedGroupsRaw, _ := d.GetChange("managed_groups")
+	oldManagedGroups := oldManagedGroupsRaw.([]interface{})
 	newManagedGroups := determineGroupsToManage(newRuleGroups, d)
 
 	// Convert old managed groups to string slice

--- a/mimir/resource_mimir_rules_test.go
+++ b/mimir/resource_mimir_rules_test.go
@@ -354,6 +354,13 @@ func TestAccResourceMimirRules_Update_RemoveGroup(t *testing.T) {
 				Config: testAccResourceMimirRules_removeGroup,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMimirNamespaceExists("mimir_rules.rules_1", "alert_group_1", client),
+					// Regression guard: the removed group must actually be gone from
+					// Mimir, not merely dropped from Terraform state. Update used to
+					// read managed_groups via d.Get (which returns the new planned
+					// value after CustomizeDiff), so groupsToDelete was always empty
+					// and removed groups silently became orphaned/unmanaged rule
+					// groups in Mimir.
+					testAccCheckMimirRuleGroupGone("mimir_rules.rules_1", "record_group_1", client),
 					resource.TestCheckResourceAttr("mimir_rules.rules_1", "groups_count", "1"),
 					resource.TestCheckResourceAttr("mimir_rules.rules_1", "managed_groups.0", "alert_group_1"),
 				),

--- a/mimir/shared_test.go
+++ b/mimir/shared_test.go
@@ -86,6 +86,37 @@ func testAccCheckMimirNamespaceExists(n string, name string, client *apiClient) 
 	}
 }
 
+// testAccCheckMimirRuleGroupGone verifies that a specific rule group within a
+// namespace has actually been removed from Mimir (returns 404). Use this in
+// Update tests that remove a group from the YAML to guard against the
+// regression where Update silently keeps orphaned groups alive in Mimir while
+// dropping them from Terraform state.
+func testAccCheckMimirRuleGroupGone(n string, groupName string, client *apiClient) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("mimir object not found in terraform state: %s", n)
+		}
+
+		orgID := rs.Primary.Attributes["org_id"]
+		namespace := rs.Primary.Attributes["namespace"]
+
+		headers := make(map[string]string)
+		if orgID != "" {
+			headers["X-Scope-OrgID"] = orgID
+		}
+		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, groupName)
+		_, err := client.sendRequest("ruler", "GET", path, "", headers)
+		if err == nil {
+			return fmt.Errorf("rule group %q in namespace %q still exists in Mimir; expected 404", groupName, namespace)
+		}
+		if !strings.Contains(err.Error(), "response code '404'") {
+			return fmt.Errorf("unexpected error checking rule group %q is gone: %w", groupName, err)
+		}
+		return nil
+	}
+}
+
 func testAccCheckMimirRuleGroupDestroy(s *terraform.State) error {
 	// retrieve the connection established in Provider configuration
 	client := testAccProvider.Meta().(*apiClient)


### PR DESCRIPTION
## What this fixes

When a rule group is removed from the YAML and `terraform apply` is run, the group is now actually **DELETED from Mimir** (`DELETE /config/v1/rules/<namespace>/<group>`). Before this PR, the group survived in Mimir as an orphan: Terraform dropped it from state, plans showed clean, but the group kept firing alerts forever with nothing managing it.

## Root cause

`resourceMimirRulesUpdate` reads the previous `managed_groups` via `d.Get`:

```go
oldManagedGroups := d.Get("managed_groups").([]interface{})
newManagedGroups := determineGroupsToManage(newRuleGroups, d)
groupsToDelete := difference(oldGroups, newManagedGroups)
```

But `CustomizeDiff` has already overwritten that field with the **new planned value** via `diff.SetNew("managed_groups", managedGroups)` at `resource_mimir_rules.go:249`. So `oldManagedGroups == newManagedGroups`, `groupsToDelete` is always empty, and the delete loop at line 543 never runs. `createRuleGroup` then upserts the surviving groups, the removed group is untouched in Mimir, and `setComputedFields` shrinks `managed_groups` in state → orphan.

## Fix

Read the prior value via `d.GetChange("managed_groups")`, which returns the state value, so `groupsToDelete` correctly contains the removed groups and `deleteRuleGroup` runs for each. This is the same API the function's own error-recovery path already uses at `resource_mimir_rules.go:563`.

One-line change, no schema migration. Existing state files get correct delete behavior on the next Update.

## Test plan

- New helper `testAccCheckMimirRuleGroupGone` in `mimir/shared_test.go` asserts a rule group returns 404 from Mimir.
- `TestAccResourceMimirRules_Update_RemoveGroup` now asserts the removed `record_group_1` is actually **gone from Mimir** (404), not just dropped from Terraform state. Without the source fix, this acceptance test fails.
- `go build ./...`, `go vet ./...`, and non-acc `go test ./...` pass locally.
- Full acceptance tests (`TF_ACC=1`) need a real Mimir; please run in CI.