### PR TITLE
feat: support group-level labels for rule-group resources

### DIFF
--- a/docs/resources/rule_group_alerting.md
+++ b/docs/resources/rule_group_alerting.md
@@ -16,6 +16,10 @@ description: |-
 resource "mimir_rule_group_alerting" "test" {
   name      = "test1"
   namespace = "namespace1"
+  # Group-level labels are added to every rule in the group (requires Mimir >= 3.0.0).
+  labels = {
+    target_channel = "Storage"
+  }
   rule {
     alert       = "HighRequestLatency"
     expr        = "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5"
@@ -41,6 +45,7 @@ resource "mimir_rule_group_alerting" "test" {
 ### Optional
 
 - `interval` (String) Alerting Rule group interval
+- `labels` (Map of String) Group-level labels added to all rules in the group. Requires Mimir >= 3.0.0 to be persisted (older Mimir accepts but drops them).
 - `namespace` (String) Alerting Rule group namespace
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `source_tenants` (List of String) Allows aggregating data from multiple tenants while evaluating a rule group.

--- a/docs/resources/rule_group_recording.md
+++ b/docs/resources/rule_group_recording.md
@@ -18,6 +18,10 @@ resource "mimir_rule_group_recording" "test" {
   namespace    = "namespace1"
   interval     = "6h"
   query_offset = "5m"
+  # Group-level labels are added to every rule in the group (requires Mimir >= 3.0.0).
+  labels = {
+    team = "observability"
+  }
   rule {
     expr   = "sum by (job) (http_inprogress_requests)"
     record = "job:http_inprogress_requests:sum"
@@ -37,6 +41,7 @@ resource "mimir_rule_group_recording" "test" {
 
 - `evaluation_delay` (String, Deprecated) **Deprecated** The duration by which to delay the execution of the recording rule.
 - `interval` (String) Recording Rule group interval
+- `labels` (Map of String) Group-level labels added to all rules in the group. Requires Mimir >= 3.0.0 to be persisted (older Mimir accepts but drops them).
 - `namespace` (String) Recording Rule group namespace
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `query_offset` (String) The duration by which to delay the execution of the recording rule.

--- a/docs/resources/rules.md
+++ b/docs/resources/rules.md
@@ -4,10 +4,10 @@ page_title: "mimir_rules Resource - terraform-provider-mimir"
 subcategory: ""
 description: |-
   Manages multiple Grafana Mimir rule groups within a namespace.
-          This resource is designed to handle YAML files containing multiple rule groups,
-          such as those exported from mimirtool or monitoring mixins. Each rule group
-          is managed individually via the Mimir API, but they are tracked together as
-          a single Terraform resource for easier bulk management.
+  This resource is designed to handle YAML files containing multiple rule groups,
+  such as those exported from mimirtool or monitoring mixins. Each rule group
+  is managed individually via the Mimir API, but they are tracked together as
+  a single Terraform resource for easier bulk management.
 ---
 
 # mimir_rules (Resource)
@@ -29,8 +29,8 @@ Manages multiple Grafana Mimir rule groups within a namespace.
 
 ### Optional
 
-- `content` (String) YAML content containing rule groups. Mutually exclusive with 'content_file'.
-- `content_file` (String) Path to YAML file containing rule groups. Mutually exclusive with 'content'.
+- `content` (String) YAML content containing rule groups. Mutually exclusive with 'content_file'. Group-level `labels` are supported and require Mimir >= 3.0.0 to be persisted (older Mimir accepts but drops them).
+- `content_file` (String) Path to YAML file containing rule groups. Mutually exclusive with 'content'. Group-level `labels` in the file are supported and require Mimir >= 3.0.0 to be persisted (older Mimir accepts but drops them).
 - `ignore_groups` (Set of String) List of rule group names to ignore from the content. Useful when you want to manage most groups but exclude specific ones.
 - `only_groups` (Set of String) Explicit list of rule group names to manage. If not specified, all groups in the content will be managed. Use this to manage only specific groups from a larger YAML file.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
@@ -55,5 +55,3 @@ Read-Only:
 - `name` (String)
 - `recording_rules_count` (Number)
 - `rules_count` (Number)
-
-

--- a/examples/resources/mimir_rule_group_alerting/resource.tf
+++ b/examples/resources/mimir_rule_group_alerting/resource.tf
@@ -1,6 +1,10 @@
 resource "mimir_rule_group_alerting" "test" {
   name      = "test1"
   namespace = "namespace1"
+  # Group-level labels are added to every rule in the group (requires Mimir >= 3.0.0).
+  labels = {
+    target_channel = "Storage"
+  }
   rule {
     alert       = "HighRequestLatency"
     expr        = "job:request_latency_seconds:mean5m{job=\"myjob\"} > 0.5"

--- a/examples/resources/mimir_rule_group_recording/resource.tf
+++ b/examples/resources/mimir_rule_group_recording/resource.tf
@@ -3,6 +3,10 @@ resource "mimir_rule_group_recording" "test" {
   namespace    = "namespace1"
   interval     = "6h"
   query_offset = "5m"
+  # Group-level labels are added to every rule in the group (requires Mimir >= 3.0.0).
+  labels = {
+    team = "observability"
+  }
   rule {
     expr   = "sum by (job) (http_inprogress_requests)"
     record = "job:http_inprogress_requests:sum"

--- a/mimir/constants.go
+++ b/mimir/constants.go
@@ -5,6 +5,7 @@ const (
 	orgIDDescription  = "The Organization ID. If not set, the Org ID defined in the provider block will be used."
 	namespaceKey      = "namespace"
 	intervalKey       = "interval"
+	labelsKey         = "labels"
 	contentTypeHeader = "Content-Type"
 	contentTypeYAML   = "application/yaml"
 

--- a/mimir/resource_mimir_rule_group_alerting.go
+++ b/mimir/resource_mimir_rule_group_alerting.go
@@ -54,6 +54,13 @@ func resourcemimirRuleGroupAlerting() *schema.Resource {
 				Description: "Allows aggregating data from multiple tenants while evaluating a rule group.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			labelsKey: {
+				Type:         schema.TypeMap,
+				Optional:     true,
+				Description:  "Group-level labels added to all rules in the group. Requires Mimir >= 3.0.0 to be persisted (older Mimir accepts but drops them).",
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				ValidateFunc: validateLabels,
+			},
 			"rule": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -93,7 +100,7 @@ func resourcemimirRuleGroupAlerting() *schema.Resource {
 							Elem:         &schema.Schema{Type: schema.TypeString},
 							ValidateFunc: validateAnnotations,
 						},
-						"labels": {
+						labelsKey: {
 							Type:         schema.TypeMap,
 							Description:  "Labels to add or overwrite for each alert.",
 							Optional:     true,
@@ -142,6 +149,9 @@ func resourcemimirRuleGroupAlertingCreate(ctx context.Context, d *schema.Resourc
 		Interval:      d.Get(intervalKey).(string),
 		SourceTenants: expandStringArray(d.Get("source_tenants").([]interface{})),
 		Rules:         expandAlertingRules(d.Get("rule").([]interface{})),
+	}
+	if v, ok := d.GetOk(labelsKey); ok {
+		rules.Labels = expandStringMap(v.(map[string]interface{}))
 	}
 	data, _ := yaml.Marshal(rules)
 	headers := map[string]string{contentTypeHeader: contentTypeYAML}
@@ -245,12 +255,16 @@ func resourcemimirRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	err = d.Set(labelsKey, data.Labels)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }
 
 func resourcemimirRuleGroupAlertingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChanges("rule", intervalKey, "source_tenants") {
+	if d.HasChanges("rule", intervalKey, "source_tenants", labelsKey) {
 		client := meta.(*apiClient)
 		name := d.Get("name").(string)
 		namespace := d.Get(namespaceKey).(string)
@@ -261,6 +275,9 @@ func resourcemimirRuleGroupAlertingUpdate(ctx context.Context, d *schema.Resourc
 			Interval:      d.Get(intervalKey).(string),
 			SourceTenants: expandStringArray(d.Get("source_tenants").([]interface{})),
 			Rules:         expandAlertingRules(d.Get("rule").([]interface{})),
+		}
+		if v, ok := d.GetOk(labelsKey); ok {
+			rules.Labels = expandStringMap(v.(map[string]interface{}))
 		}
 		data, _ := yaml.Marshal(rules)
 		headers := map[string]string{contentTypeHeader: contentTypeYAML}
@@ -357,7 +374,7 @@ func expandAlertingRules(v []interface{}) []alertingRule {
 			}
 		}
 
-		if raw, ok := data["labels"]; ok {
+		if raw, ok := data[labelsKey]; ok {
 			if len(raw.(map[string]interface{})) > 0 {
 				rule.Labels = expandStringMap(raw.(map[string]interface{}))
 			}
@@ -394,7 +411,7 @@ func flattenAlertingRules(v []alertingRule) []map[string]interface{} {
 			rule["keep_firing_for"] = v.KeepFiringFor
 		}
 		if v.Labels != nil {
-			rule["labels"] = v.Labels
+			rule[labelsKey] = v.Labels
 		}
 		if v.Annotations != nil {
 			rule["annotations"] = v.Annotations
@@ -427,8 +444,9 @@ type alertingRule struct {
 }
 
 type alertingRuleGroup struct {
-	Name          string         `yaml:"name"`
-	Interval      string         `yaml:"interval,omitempty"`
-	Rules         []alertingRule `yaml:"rules"`
-	SourceTenants []string       `yaml:"source_tenants,omitempty"`
+	Name          string            `yaml:"name"`
+	Interval      string            `yaml:"interval,omitempty"`
+	Rules         []alertingRule    `yaml:"rules"`
+	SourceTenants []string          `yaml:"source_tenants,omitempty"`
+	Labels        map[string]string `yaml:"labels,omitempty"`
 }

--- a/mimir/resource_mimir_rule_group_alerting_test.go
+++ b/mimir/resource_mimir_rule_group_alerting_test.go
@@ -472,3 +472,88 @@ const testAccResourceRuleGroupAlerting_withOrgID = `
             }
     }
 `
+
+// TestAccResourceRuleGroupAlerting_GroupLabels exercises group-level labels
+// (EDPIPIF-1516): create WITHOUT group labels, then ADD them (must trigger the
+// HasChanges("labels") gate + POST and round-trip on Read), then change the value.
+// Requires Mimir >= 3.0.0 to persist group-level labels.
+func TestAccResourceRuleGroupAlerting_GroupLabels(t *testing.T) {
+	skipBelowMimirVersion(t, "3.0.0")
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceRuleGroupAlerting_groupLabelsNone,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.labeled", "labeled_group", client),
+					resource.TestCheckNoResourceAttr("mimir_rule_group_alerting.labeled", "labels.target_channel"),
+				),
+			},
+			{
+				Config: testAccResourceRuleGroupAlerting_groupLabelsStorage,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.labeled", "labeled_group", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.labeled", "labels.target_channel", "Storage"),
+				),
+			},
+			{
+				Config: testAccResourceRuleGroupAlerting_groupLabelsNetwork,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.labeled", "labels.target_channel", "Network"),
+				),
+			},
+			{
+				// remove the group labels entirely: HasChanges fires, POST replaces
+				// the group without labels, Read clears state (proves full-replace, not merge).
+				Config: testAccResourceRuleGroupAlerting_groupLabelsNone,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.labeled", "labeled_group", client),
+					resource.TestCheckNoResourceAttr("mimir_rule_group_alerting.labeled", "labels.target_channel"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceRuleGroupAlerting_groupLabelsNone = `
+	resource "mimir_rule_group_alerting" "labeled" {
+		name      = "labeled_group"
+		namespace = "namespace_labels"
+		rule {
+			alert = "Instancedown"
+			expr  = "up == 0"
+		}
+	}
+`
+const testAccResourceRuleGroupAlerting_groupLabelsStorage = `
+	resource "mimir_rule_group_alerting" "labeled" {
+		name      = "labeled_group"
+		namespace = "namespace_labels"
+		labels = {
+			target_channel = "Storage"
+		}
+		rule {
+			alert = "Instancedown"
+			expr  = "up == 0"
+		}
+	}
+`
+const testAccResourceRuleGroupAlerting_groupLabelsNetwork = `
+	resource "mimir_rule_group_alerting" "labeled" {
+		name      = "labeled_group"
+		namespace = "namespace_labels"
+		labels = {
+			target_channel = "Network"
+		}
+		rule {
+			alert = "Instancedown"
+			expr  = "up == 0"
+		}
+	}
+`

--- a/mimir/resource_mimir_rule_group_recording.go
+++ b/mimir/resource_mimir_rule_group_recording.go
@@ -69,6 +69,13 @@ func resourcemimirRuleGroupRecording() *schema.Resource {
 				Description: "Allows aggregating data from multiple tenants while evaluating a rule group.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			labelsKey: {
+				Type:         schema.TypeMap,
+				Optional:     true,
+				Description:  "Group-level labels added to all rules in the group. Requires Mimir >= 3.0.0 to be persisted (older Mimir accepts but drops them).",
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				ValidateFunc: validateLabels,
+			},
 			"rule": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -87,7 +94,7 @@ func resourcemimirRuleGroupRecording() *schema.Resource {
 							ValidateFunc: validatePromQLExpr,
 							StateFunc:    formatPromQLExpr,
 						},
-						"labels": {
+						labelsKey: {
 							Type:         schema.TypeMap,
 							Description:  "Labels to add or overwrite before storing the result.",
 							Optional:     true,
@@ -138,6 +145,9 @@ func resourcemimirRuleGroupRecordingCreate(ctx context.Context, d *schema.Resour
 		QueryOffset:     d.Get("query_offset").(string),
 		SourceTenants:   expandStringArray(d.Get("source_tenants").([]interface{})),
 		Rules:           expandRecordingRules(d.Get("rule").([]interface{})),
+	}
+	if v, ok := d.GetOk(labelsKey); ok {
+		rules.Labels = expandStringMap(v.(map[string]interface{}))
 	}
 	// if ed, ok := d.GetOk("evaluation_delay"); ok {
 	// 	rules.EvaluationDelay = ed.(string)
@@ -257,11 +267,15 @@ func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resource
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	err = d.Set(labelsKey, data.Labels)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return diags
 }
 
 func resourcemimirRuleGroupRecordingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChanges("rule", intervalKey, "query_offset", "evaluation_delay", "source_tenants") {
+	if d.HasChanges("rule", intervalKey, "query_offset", "evaluation_delay", "source_tenants", labelsKey) {
 		client := meta.(*apiClient)
 		name := d.Get("name").(string)
 		namespace := d.Get(namespaceKey).(string)
@@ -277,6 +291,9 @@ func resourcemimirRuleGroupRecordingUpdate(ctx context.Context, d *schema.Resour
 			rules.EvaluationDelay = ed.(string)
 		} else {
 			rules.QueryOffset = d.Get("query_offset").(string)
+		}
+		if v, ok := d.GetOk(labelsKey); ok {
+			rules.Labels = expandStringMap(v.(map[string]interface{}))
 		}
 		data, _ := yaml.Marshal(rules)
 		headers := map[string]string{contentTypeHeader: contentTypeYAML}
@@ -360,7 +377,7 @@ func expandRecordingRules(v []interface{}) []recordingRule {
 			rule.Expr = formatPromQLExpr(raw)
 		}
 
-		if raw, ok := data["labels"]; ok {
+		if raw, ok := data[labelsKey]; ok {
 			if len(raw.(map[string]interface{})) > 0 {
 				rule.Labels = expandStringMap(raw.(map[string]interface{}))
 			}
@@ -385,7 +402,7 @@ func flattenRecordingRules(v []recordingRule) []map[string]interface{} {
 		rule["expr"] = formatPromQLExpr(v.Expr)
 
 		if v.Labels != nil {
-			rule["labels"] = v.Labels
+			rule[labelsKey] = v.Labels
 		}
 
 		rules = append(rules, rule)
@@ -412,10 +429,11 @@ type recordingRule struct {
 }
 
 type recordingRuleGroup struct {
-	Name            string          `yaml:"name"`
-	Interval        string          `yaml:"interval,omitempty"`
-	QueryOffset     string          `yaml:"query_offset,omitempty"`
-	EvaluationDelay string          `yaml:"evaluation_delay,omitempty"`
-	Rules           []recordingRule `yaml:"rules"`
-	SourceTenants   []string        `yaml:"source_tenants,omitempty"`
+	Name            string            `yaml:"name"`
+	Interval        string            `yaml:"interval,omitempty"`
+	QueryOffset     string            `yaml:"query_offset,omitempty"`
+	EvaluationDelay string            `yaml:"evaluation_delay,omitempty"`
+	Rules           []recordingRule   `yaml:"rules"`
+	SourceTenants   []string          `yaml:"source_tenants,omitempty"`
+	Labels          map[string]string `yaml:"labels,omitempty"`
 }

--- a/mimir/resource_mimir_rule_group_recording_test.go
+++ b/mimir/resource_mimir_rule_group_recording_test.go
@@ -459,3 +459,86 @@ const testAccResourceRuleGroupRecording_withOrgID = `
             }
     }
 `
+
+// TestAccResourceRuleGroupRecording_GroupLabels exercises group-level labels
+// (EDPIPIF-1516) on the recording resource: create without, add, then change.
+// Requires Mimir >= 3.0.0 to persist group-level labels.
+func TestAccResourceRuleGroupRecording_GroupLabels(t *testing.T) {
+	skipBelowMimirVersion(t, "3.0.0")
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceRuleGroupRecording_groupLabelsNone,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.labeled", "labeled_rec_group", client),
+					resource.TestCheckNoResourceAttr("mimir_rule_group_recording.labeled", "labels.target_channel"),
+				),
+			},
+			{
+				Config: testAccResourceRuleGroupRecording_groupLabelsStorage,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.labeled", "labeled_rec_group", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.labeled", "labels.target_channel", "Storage"),
+				),
+			},
+			{
+				Config: testAccResourceRuleGroupRecording_groupLabelsNetwork,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.labeled", "labels.target_channel", "Network"),
+				),
+			},
+			{
+				// remove the group labels entirely (proves full-replace on Update, state cleared on Read).
+				Config: testAccResourceRuleGroupRecording_groupLabelsNone,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.labeled", "labeled_rec_group", client),
+					resource.TestCheckNoResourceAttr("mimir_rule_group_recording.labeled", "labels.target_channel"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceRuleGroupRecording_groupLabelsNone = `
+	resource "mimir_rule_group_recording" "labeled" {
+		name      = "labeled_rec_group"
+		namespace = "namespace_labels"
+		rule {
+			record = "job:up:sum"
+			expr   = "sum(up)"
+		}
+	}
+`
+const testAccResourceRuleGroupRecording_groupLabelsStorage = `
+	resource "mimir_rule_group_recording" "labeled" {
+		name      = "labeled_rec_group"
+		namespace = "namespace_labels"
+		labels = {
+			target_channel = "Storage"
+		}
+		rule {
+			record = "job:up:sum"
+			expr   = "sum(up)"
+		}
+	}
+`
+const testAccResourceRuleGroupRecording_groupLabelsNetwork = `
+	resource "mimir_rule_group_recording" "labeled" {
+		name      = "labeled_rec_group"
+		namespace = "namespace_labels"
+		labels = {
+			target_channel = "Network"
+		}
+		rule {
+			record = "job:up:sum"
+			expr   = "sum(up)"
+		}
+	}
+`

--- a/mimir/resource_mimir_rules.go
+++ b/mimir/resource_mimir_rules.go
@@ -28,6 +28,9 @@ type RuleGroup struct {
 	Rules           []Rule   `yaml:"rules"`
 	SourceTenants   []string `yaml:"source_tenants,omitempty"`
 	Limit           int      `yaml:"limit,omitempty"`
+	// Labels are group-level labels applied to all rules in the group.
+	// Requires Mimir >= 3.0.0 to be persisted (older Mimir accepts but drops them).
+	Labels map[string]string `yaml:"labels,omitempty"`
 }
 
 // Rule represents both alerting and recording rules
@@ -83,7 +86,7 @@ func resourceMimirRules() *schema.Resource {
 			"content": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Description:   "YAML content containing rule groups. Mutually exclusive with 'content_file'.",
+				Description:   "YAML content containing rule groups. Mutually exclusive with 'content_file'. Group-level `labels` are supported and require Mimir >= 3.0.0 to be persisted (older Mimir accepts but drops them).",
 				ValidateFunc:  validateYAMLContent,
 				ConflictsWith: []string{"content_file"},
 			},
@@ -91,7 +94,7 @@ func resourceMimirRules() *schema.Resource {
 			"content_file": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Description:   "Path to YAML file containing rule groups. Mutually exclusive with 'content'.",
+				Description:   "Path to YAML file containing rule groups. Mutually exclusive with 'content'. Group-level `labels` in the file are supported and require Mimir >= 3.0.0 to be persisted (older Mimir accepts but drops them).",
 				ValidateFunc:  validation.StringIsNotEmpty,
 				ConflictsWith: []string{"content"},
 			},

--- a/mimir/resource_mimir_rules_test.go
+++ b/mimir/resource_mimir_rules_test.go
@@ -6,7 +6,50 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"gopkg.in/yaml.v3"
 )
+
+// TestRuleGroupContentPreservesGroupLabels proves group-level labels survive the
+// parse -> marshal round-trip used by Create (POST body) and calculateContentHash
+// (drift) for the mimir_rules resource. Before the Labels field was added to
+// RuleGroup, a group-level `labels:` key was silently dropped (EDPIPIF-1516).
+func TestRuleGroupContentPreservesGroupLabels(t *testing.T) {
+	ruleGroups := RuleGroups{
+		Groups: []RuleGroup{
+			{
+				Name:   "harvest_alerts",
+				Labels: map[string]string{"target_channel": "Storage"},
+				Rules: []Rule{
+					{
+						Alert:  "Instancedown",
+						Expr:   "up == 0",
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := validateRuleGroupsContent(ruleGroups); err != nil {
+		t.Fatalf("group-level labels should be valid, got: %v", err)
+	}
+
+	data, err := yaml.Marshal(ruleGroups)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var rt RuleGroups
+	if err := yaml.Unmarshal(data, &rt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(rt.Groups) != 1 {
+		t.Fatalf("expected 1 group after round-trip, got %d", len(rt.Groups))
+	}
+	if got := rt.Groups[0].Labels["target_channel"]; got != "Storage" {
+		t.Fatalf("group-level label target_channel not preserved through round-trip; got %q\nyaml:\n%s", got, data)
+	}
+}
 
 func TestValidateRuleGroupsContent_AllowsPrometheusDurations(t *testing.T) {
 	ruleGroups := RuleGroups{
@@ -594,6 +637,58 @@ groups:
           severity: critical
         annotations:
           summary: "High memory usage detected"
+EOT
+}
+`
+
+// TestAccResourceMimirRules_GroupLabels covers group-level labels via the
+// combined mimir_rules (YAML content) resource (EDPIPIF-1516, original repro:
+// group harvest_alerts with target_channel: Storage). Group labels live inside
+// the content YAML, not Terraform state attributes, so they are asserted via the
+// ruler API with testAccCheckMimirRuleGroupHasLabel. Requires Mimir >= 3.0.0.
+func TestAccResourceMimirRules_GroupLabels(t *testing.T) {
+	skipBelowMimirVersion(t, "3.0.0")
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceMimirRules_groupLabels,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupHasLabel("mimir_rules.harvest", "harvest_alerts", "target_channel", "Storage", client),
+				),
+			},
+			{
+				// re-apply identical config: the post-apply plan must be empty (no drift).
+				Config: testAccResourceMimirRules_groupLabels,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupHasLabel("mimir_rules.harvest", "harvest_alerts", "target_channel", "Storage", client),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceMimirRules_groupLabels = `
+resource "mimir_rules" "harvest" {
+  namespace = "harvest"
+
+  content = <<-EOT
+groups:
+  - name: harvest_alerts
+    labels:
+      target_channel: Storage
+    rules:
+      - alert: Instancedown
+        expr: up == 0
+        for: 5m
+        labels:
+          severity: critical
 EOT
 }
 `

--- a/mimir/shared_test.go
+++ b/mimir/shared_test.go
@@ -5,10 +5,68 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"gopkg.in/yaml.v3"
 )
+
+// skipBelowMimirVersion skips a test when MIMIR_VERSION is unset, unparseable, or
+// below min. Unlike the older inline pattern (version.NewVersion(os.Getenv(...))
+// then .LessThan, which nil-panics on an empty MIMIR_VERSION and uses bare
+// `return` that go test reports as PASS), this guards the empty/unparseable case
+// and uses t.Skip so the gate produces a real `--- SKIP`.
+func skipBelowMimirVersion(t *testing.T, min string) {
+	t.Helper()
+	v := os.Getenv("MIMIR_VERSION")
+	if v == "" {
+		t.Skipf("MIMIR_VERSION not set; skipping test requiring Mimir >= %s", min)
+	}
+	cur, err := version.NewVersion(v)
+	if err != nil {
+		t.Skipf("MIMIR_VERSION %q unparseable; skipping test requiring Mimir >= %s", v, min)
+	}
+	minV, _ := version.NewVersion(min)
+	if cur.LessThan(minV) {
+		t.Skipf("Mimir %s < %s; skipping group-label persistence test", cur, minV)
+	}
+}
+
+// testAccCheckMimirRuleGroupHasLabel GETs a rule group from the ruler API and
+// asserts it carries a group-level label key=val. Used for mimir_rules, whose
+// group labels live inside the YAML content and are not Terraform state
+// attributes (so resource.TestCheckResourceAttr cannot see them).
+func testAccCheckMimirRuleGroupHasLabel(n, group, key, val string, client *apiClient) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("mimir object not found in terraform state: %s", n)
+		}
+		orgID := rs.Primary.Attributes["org_id"]
+		namespace := rs.Primary.Attributes["namespace"]
+		headers := make(map[string]string)
+		if orgID != "" {
+			headers["X-Scope-OrgID"] = orgID
+		}
+		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, group)
+		body, err := client.sendRequest("ruler", "GET", path, "", headers)
+		if err != nil {
+			return err
+		}
+		var grp struct {
+			Labels map[string]string `yaml:"labels"`
+		}
+		if err := yaml.Unmarshal([]byte(body), &grp); err != nil {
+			return fmt.Errorf("parsing rule group %q YAML: %w", group, err)
+		}
+		if got := grp.Labels[key]; got != val {
+			return fmt.Errorf("rule group %q label %q = %q, want %q (body: %s)", group, key, got, val, body)
+		}
+		return nil
+	}
+}
 
 func getSetEnv(key, fallback string) string {
 	value, exists := os.LookupEnv(key)


### PR DESCRIPTION
## Summary

Adds support for **group-level `labels`** on rule-group resources. A rule group can carry labels applied to all of its rules (commonly used for notification routing, e.g. `target_channel`). Previously the provider dropped group-level labels entirely.

This covers all three rule-group resources:

- **`mimir_rule_group_alerting`** / **`mimir_rule_group_recording`** (typed): new optional top-level `labels` map (`TypeMap`), expanded into the group on Create/Update, included in the `HasChanges` gate so a label-only edit triggers an update, and set back from the API on Read for a drift-free round-trip.
- **`mimir_rules`** (combined YAML): adds the `Labels` field to the `RuleGroup` struct so a group-level `labels:` key in the YAML `content`/`content_file` reaches the backend (POST body) and the content hash, instead of being silently dropped on unmarshal.

## Version requirement

Group-level rule-group labels are only **persisted by Mimir >= 3.0.0** (Prometheus added the `rulefmt` group `Labels` field in 3.0.0; Mimir's ruler honours it from 3.0.0). On older Mimir the config API accepts the labels but drops them. This is documented on each schema attribute's description. On a typed resource against Mimir < 3.0.0 this means a non-converging plan (the server returns no labels); the requirement is documented rather than enforced at runtime.

## Tests

- Unit: `TestRuleGroupContentPreservesGroupLabels` — group labels survive the parse → marshal round-trip used by Create and the content hash.
- Acceptance (version-gated, skipped < 3.0.0): `TestAccResourceRuleGroupAlerting_GroupLabels`, `TestAccResourceRuleGroupRecording_GroupLabels`, `TestAccResourceMimirRules_GroupLabels` — create without labels, add labels (exercises the `HasChanges` gate), change the value, and (for `mimir_rules`) assert via the ruler API + a no-drift re-apply.
- `make testacc` passes on **Mimir 3.0.6** and **2.17.10** (the group-label tests `--- SKIP` on 2.17.10); `golangci-lint` clean; docs regenerated via `tfplugindocs`.
