### PR TITLE
feat: relax rule/alert name validation and escape ruler URL paths

### DIFF
--- a/mimir/constants.go
+++ b/mimir/constants.go
@@ -4,6 +4,7 @@ const (
 	orgIDKey          = "org_id"
 	orgIDDescription  = "The Organization ID. If not set, the Org ID defined in the provider block will be used."
 	namespaceKey      = "namespace"
+	defaultNamespace  = "default"
 	intervalKey       = "interval"
 	labelsKey         = "labels"
 	contentTypeHeader = "Content-Type"

--- a/mimir/data_source_mimir_rule_group_alerting.go
+++ b/mimir/data_source_mimir_rule_group_alerting.go
@@ -16,17 +16,19 @@ func dataSourcemimirRuleGroupAlerting() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			orgIDKey: {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Description: orgIDDescription,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Description:  orgIDDescription,
+				ValidateFunc: validateOrgID,
 			},
 			"namespace": {
-				Type:        schema.TypeString,
-				Description: "Alerting Rule group namespace",
-				ForceNew:    true,
-				Optional:    true,
-				Default:     "default",
+				Type:         schema.TypeString,
+				Description:  "Alerting Rule group namespace",
+				ForceNew:     true,
+				Optional:     true,
+				Default:      defaultNamespace,
+				ValidateFunc: validateNamespace,
 			},
 			"name": {
 				Type:         schema.TypeString,
@@ -87,14 +89,13 @@ func dataSourcemimirRuleGroupAlertingRead(ctx context.Context, d *schema.Resourc
 	namespace := d.Get("namespace").(string)
 	orgID := d.Get(orgIDKey).(string)
 
-	id := fmt.Sprintf("%s/%s", namespace, name)
+	id := buildRuleGroupID(orgID, namespace, name)
 
 	headers := make(map[string]string)
 	if orgID != "" {
 		headers["X-Scope-OrgID"] = orgID
-		id = fmt.Sprintf("%s/%s/%s", orgID, namespace, name)
 	}
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	path := rulesGroupPath(namespace, name)
 	jobraw, err := client.sendRequest("ruler", "GET", path, "", headers)
 
 	baseMsg := fmt.Sprintf("Cannot read alerting rule group '%s' -", name)

--- a/mimir/data_source_mimir_rule_group_recording.go
+++ b/mimir/data_source_mimir_rule_group_recording.go
@@ -16,17 +16,19 @@ func dataSourcemimirRuleGroupRecording() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			orgIDKey: {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Description: orgIDDescription,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Description:  orgIDDescription,
+				ValidateFunc: validateOrgID,
 			},
 			"namespace": {
-				Type:        schema.TypeString,
-				Description: "Recording Rule group namespace",
-				ForceNew:    true,
-				Optional:    true,
-				Default:     "default",
+				Type:         schema.TypeString,
+				Description:  "Recording Rule group namespace",
+				ForceNew:     true,
+				Optional:     true,
+				Default:      defaultNamespace,
+				ValidateFunc: validateNamespace,
 			},
 			"name": {
 				Type:         schema.TypeString,
@@ -90,14 +92,13 @@ func dataSourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.Resour
 	namespace := d.Get("namespace").(string)
 	orgID := d.Get(orgIDKey).(string)
 
-	id := fmt.Sprintf("%s/%s", namespace, name)
+	id := buildRuleGroupID(orgID, namespace, name)
 
 	headers := make(map[string]string)
 	if orgID != "" {
 		headers["X-Scope-OrgID"] = orgID
-		id = fmt.Sprintf("%s/%s/%s", orgID, namespace, name)
 	}
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	path := rulesGroupPath(namespace, name)
 	jobraw, err := client.sendRequest("ruler", "GET", path, "", headers)
 
 	baseMsg := fmt.Sprintf("Cannot read recording rule group '%s' -", name)

--- a/mimir/name_validation_test.go
+++ b/mimir/name_validation_test.go
@@ -1,0 +1,249 @@
+package mimir
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestValidRuleName(t *testing.T) {
+	accept := []string{"LUN Destroyed", "Harvest Rules", `alert{env="prod"}`, "50% full", "café", "..dotstart", "a.b", "test1_alert"}
+	reject := []string{"", "   ", "a\x00b", "a\nb", "a/b", ".", ".."}
+
+	for _, s := range accept {
+		if !validRuleName(s) {
+			t.Errorf("validRuleName(%q) = false, want true", s)
+		}
+		if _, errs := validateGroupRuleName(s, "name"); len(errs) != 0 {
+			t.Errorf("validateGroupRuleName(%q) rejected an accept-case: %v", s, errs)
+		}
+		if _, errs := validateAlertingRuleName(s, "alert"); len(errs) != 0 {
+			t.Errorf("validateAlertingRuleName(%q) rejected an accept-case: %v", s, errs)
+		}
+	}
+	for _, s := range reject {
+		if validRuleName(s) {
+			t.Errorf("validRuleName(%q) = true, want false", s)
+		}
+		if _, errs := validateGroupRuleName(s, "name"); len(errs) == 0 {
+			t.Errorf("validateGroupRuleName(%q) accepted a reject-case", s)
+		}
+		if _, errs := validateAlertingRuleName(s, "alert"); len(errs) == 0 {
+			t.Errorf("validateAlertingRuleName(%q) accepted a reject-case", s)
+		}
+	}
+}
+
+func TestValidateNamespace(t *testing.T) {
+	accept := []string{defaultNamespace, "team a", "ns.1", "", "my-namespace"}
+	reject := []string{"a/b", "a\x00b", ".", ".."}
+
+	for _, s := range accept {
+		ws, errs := validateNamespace(s, "namespace")
+		if len(errs) != 0 {
+			t.Errorf("validateNamespace(%q) rejected an accept-case: %v", s, errs)
+		}
+		if len(ws) != 0 {
+			t.Errorf("validateNamespace(%q) warned on a plain value: %v", s, ws)
+		}
+	}
+	for _, s := range reject {
+		if _, errs := validateNamespace(s, "namespace"); len(errs) == 0 {
+			t.Errorf("validateNamespace(%q) accepted a reject-case", s)
+		}
+	}
+
+	// A valid percent-encoding sequence is ACCEPTED but warned about (older provider
+	// versions let the server decode it once; it is now sent literally).
+	ws, errs := validateNamespace("team%20a", "namespace")
+	if len(errs) != 0 {
+		t.Errorf("validateNamespace(team%%20a) rejected: %v", errs)
+	}
+	if len(ws) != 1 {
+		t.Errorf("validateNamespace(team%%20a) warnings = %v, want exactly 1", ws)
+	}
+	// An invalid/bare %% is not an encoding sequence: accepted, no warning.
+	ws, errs = validateNamespace("50% full", "namespace")
+	if len(errs) != 0 || len(ws) != 0 {
+		t.Errorf("validateNamespace(50%% full) = (%v, %v), want accepted with no warning", ws, errs)
+	}
+}
+
+func TestValidateOrgID(t *testing.T) {
+	accept := []string{"", "myorg", "tenant-1", "org.1"}
+	reject := []string{"a\nb", "a\rb", "a\x00b", "a/b", ".", "..", "../other-tenant"}
+
+	for _, s := range accept {
+		if _, errs := validateOrgID(s, "org_id"); len(errs) != 0 {
+			t.Errorf("validateOrgID(%q) rejected an accept-case: %v", s, errs)
+		}
+	}
+	for _, s := range reject {
+		if _, errs := validateOrgID(s, "org_id"); len(errs) == 0 {
+			t.Errorf("validateOrgID(%q) accepted a reject-case", s)
+		}
+	}
+}
+
+func groupWith(name, alert string) RuleGroups {
+	return RuleGroups{Groups: []RuleGroup{{Name: name, Rules: []Rule{{Alert: alert, Expr: "up"}}}}}
+}
+
+func TestValidateRuleGroupsContent(t *testing.T) {
+	if err := validateRuleGroupsContent(groupWith("Harvest Rules", "LUN Destroyed")); err != nil {
+		t.Errorf("expected accept for relaxed group + alert names, got: %v", err)
+	}
+	if err := validateRuleGroupsContent(groupWith("", "A")); err == nil {
+		t.Error("expected reject for empty group name")
+	}
+	if err := validateRuleGroupsContent(groupWith("a/b", "A")); err == nil {
+		t.Error("expected reject for '/' in group name")
+	}
+	if err := validateRuleGroupsContent(groupWith("g", "a/b")); err == nil {
+		t.Error("expected reject for '/' in alert name")
+	}
+}
+
+func TestValidateRule(t *testing.T) {
+	if err := validateRule(Rule{Alert: "LUN Destroyed", Expr: "up"}, 0, 0, "g"); err != nil {
+		t.Errorf("expected accept for relaxed alert name, got: %v", err)
+	}
+	if err := validateRule(Rule{Alert: "a/b", Expr: "up"}, 0, 0, "g"); err == nil {
+		t.Error("expected reject for '/' in alert name")
+	}
+	// record name stays strict (metricNameRegexp): a space is invalid
+	if err := validateRule(Rule{Record: "bad record", Expr: "up"}, 0, 0, "g"); err == nil {
+		t.Error("expected record name to stay strict (reject space)")
+	}
+	if err := validateRule(Rule{Record: "valid_record", Expr: "up"}, 0, 0, "g"); err != nil {
+		t.Errorf("expected valid record name accepted, got: %v", err)
+	}
+}
+
+func TestParseRuleGroupID(t *testing.T) {
+	// round-trip an ordinary 2-segment and 3-segment id
+	cases := []struct{ org, ns, name string }{
+		{"", defaultNamespace, "my group"},
+		{"tenant-1", "ns a", "grp%x"},
+	}
+	for _, c := range cases {
+		id := buildRuleGroupID(c.org, c.ns, c.name)
+		org, ns, name, err := parseRuleGroupID(id)
+		if err != nil {
+			t.Errorf("parseRuleGroupID(%q) unexpected error: %v", id, err)
+			continue
+		}
+		if org != c.org || ns != c.ns || name != c.name {
+			t.Errorf("round-trip mismatch for %q: got (%q,%q,%q) want (%q,%q,%q)", id, org, ns, name, c.org, c.ns, c.name)
+		}
+	}
+	// a raw '/'-in-namespace can only be expressed escaped, which decodes and is rejected
+	if _, _, _, err := parseRuleGroupID("a%2Fb/c"); err == nil {
+		t.Error("expected reject for a namespace containing '/' (escaped) in the id")
+	}
+	// a bad percent-encoding (legacy unescaped ID) falls back to the raw segment, not a hard fail
+	if _, _, name, err := parseRuleGroupID("ns/50%zz"); err != nil || name != "50%zz" {
+		t.Errorf("expected legacy raw fallback for bad encoding: name=%q err=%v", name, err)
+	}
+	// dot-segment name rejected on the parse path
+	if _, _, _, err := parseRuleGroupID("ns/.."); err == nil {
+		t.Error("expected reject for a '..' name in the id")
+	}
+	// control char in the org_id segment rejected (covers the validOrgID call site inside parse)
+	if _, _, _, err := parseRuleGroupID("bad\rorg/ns/name"); err == nil {
+		t.Error("expected reject for a control char in the org_id segment")
+	}
+	// a '/' smuggled into the org_id segment as %2F is rejected (cross-tenant traversal vector)
+	if _, _, _, err := parseRuleGroupID("tenantA%2Fevil/ns/rule"); err == nil {
+		t.Error("expected reject for a '/' (as %2F) in the org_id segment")
+	}
+	// a ".." org_id segment is rejected
+	if _, _, _, err := parseRuleGroupID("../ns/rule"); err == nil {
+		t.Error("expected reject for a '..' org_id segment")
+	}
+	// invalid segment counts are rejected (pins the default branch against a take-first-3 refactor)
+	if _, _, _, err := parseRuleGroupID("noslash"); err == nil {
+		t.Error("expected reject for a 1-segment id")
+	}
+	if _, _, _, err := parseRuleGroupID("a/b/c/d"); err == nil {
+		t.Error("expected reject for a 4-segment id")
+	}
+	// a Unicode C1 control (NEL) in a name is rejected (covers the unicode.IsControl path)
+	if validRuleName("a\u0085b") {
+		t.Error("expected reject for a NEL (U+0085) control char in a name")
+	}
+}
+
+// TestResourceMimirRulesImport pins the importer's re-validation guards directly (no server
+// needed: the importer never touches its meta parameter). Without this, deleting the
+// validOrgID/validNamespace blocks passes the entire suite (verified by mutation).
+func TestResourceMimirRulesImport(t *testing.T) {
+	res := resourceMimirRules()
+	cases := []struct {
+		id      string
+		wantErr bool
+		org, ns string
+	}{
+		{"tenant/ns", false, "tenant", "ns"},
+		{"org/team a", false, "org", "team a"}, // spaces in a namespace are accepted
+		{"org/..", true, "", ""},               // dot-segment namespace
+		{"bad\rorg/ns", true, "", ""},          // control char in org_id
+		{"a/b/c", true, "", ""},                // wrong segment count
+		{"noslash", true, "", ""},              // wrong segment count
+	}
+	for _, c := range cases {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(c.id)
+		got, err := resourceMimirRulesImport(context.Background(), d, nil)
+		if (err != nil) != c.wantErr {
+			t.Errorf("resourceMimirRulesImport(%q) err=%v, wantErr=%v", c.id, err, c.wantErr)
+			continue
+		}
+		if err == nil {
+			if len(got) != 1 || got[0].Get(orgIDKey).(string) != c.org || got[0].Get(namespaceKey).(string) != c.ns {
+				t.Errorf("resourceMimirRulesImport(%q) set org_id/namespace = %q/%q, want %q/%q",
+					c.id, got[0].Get(orgIDKey), got[0].Get(namespaceKey), c.org, c.ns)
+			}
+		}
+	}
+}
+
+// TestGuardValidateFuncWiring pins the ATTACHMENT of the plan-time guards to every schema
+// surface, not just the validator functions: a refactor dropping a `ValidateFunc:` line
+// otherwise keeps the whole suite green (verified by mutation).
+func TestGuardValidateFuncWiring(t *testing.T) {
+	p := Provider("dev")()
+	surfaces := []struct {
+		kind, name string
+		s          *schema.Resource
+	}{
+		{"resource", "mimir_rule_group_alerting", p.ResourcesMap["mimir_rule_group_alerting"]},
+		{"resource", "mimir_rule_group_recording", p.ResourcesMap["mimir_rule_group_recording"]},
+		{"resource", "mimir_rules", p.ResourcesMap["mimir_rules"]},
+		{"data", "mimir_rule_group_alerting", p.DataSourcesMap["mimir_rule_group_alerting"]},
+		{"data", "mimir_rule_group_recording", p.DataSourcesMap["mimir_rule_group_recording"]},
+	}
+	for _, sf := range surfaces {
+		if sf.s == nil {
+			t.Fatalf("%s %q not found in provider map", sf.kind, sf.name)
+		}
+		for _, field := range []string{namespaceKey, orgIDKey} {
+			sch, ok := sf.s.Schema[field]
+			if !ok {
+				t.Errorf("%s %q: field %q missing from schema", sf.kind, sf.name, field)
+				continue
+			}
+			if sch.ValidateFunc == nil {
+				t.Errorf("%s %q: field %q has no ValidateFunc (plan-time guard dropped)", sf.kind, sf.name, field)
+				continue
+			}
+			if _, errs := sch.ValidateFunc("a/b", field); len(errs) == 0 {
+				t.Errorf("%s %q: field %q ValidateFunc accepted \"a/b\"", sf.kind, sf.name, field)
+			}
+			if _, errs := sch.ValidateFunc("valid-value", field); len(errs) != 0 {
+				t.Errorf("%s %q: field %q ValidateFunc rejected a valid value: %v", sf.kind, sf.name, field, errs)
+			}
+		}
+	}
+}

--- a/mimir/paths_test.go
+++ b/mimir/paths_test.go
@@ -1,0 +1,89 @@
+package mimir
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRulesGroupPath(t *testing.T) {
+	cases := []struct{ ns, name, want string }{
+		{defaultNamespace, "my-group", "/config/v1/rules/default/my-group"},
+		{defaultNamespace, "Harvest Rules", "/config/v1/rules/default/Harvest%20Rules"},
+		{defaultNamespace, "a/b", "/config/v1/rules/default/a%2Fb"},
+		{defaultNamespace, "50%", "/config/v1/rules/default/50%25"},
+		{defaultNamespace, "a#b", "/config/v1/rules/default/a%23b"},
+		{defaultNamespace, "a?b", "/config/v1/rules/default/a%3Fb"},
+	}
+	for _, c := range cases {
+		if got := rulesGroupPath(c.ns, c.name); got != c.want {
+			t.Errorf("rulesGroupPath(%q, %q) = %q, want %q", c.ns, c.name, got, c.want)
+		}
+	}
+	if got := rulesNamespacePath("team a"); got != "/config/v1/rules/team%20a" {
+		t.Errorf("rulesNamespacePath(space) = %q", got)
+	}
+	if got := rulesNamespacePath(defaultNamespace); got != "/config/v1/rules/default" {
+		t.Errorf("rulesNamespacePath(identity) = %q", got)
+	}
+}
+
+// TestNoRawRulerPath is a structural guard: the ruler-path literal may appear ONLY inside
+// the two sanctioned helpers. It walks every string literal in the package — including
+// package-level var/const initializers, closures, and ALL _test.go files (the round-3 defect
+// class was a raw path in a test helper; AC4 requires product AND test coverage) — and fails
+// on any occurrence outside rulesGroupPath/rulesNamespacePath. Only this file is exempt (it
+// holds the marker constant and the helpers' expected-output literals).
+func TestNoRawRulerPath(t *testing.T) {
+	const marker = "/config" + "/v1" + "/rules" // split so this literal does not flag itself elsewhere
+	allowed := map[string]bool{"rulesGroupPath": true, "rulesNamespacePath": true}
+
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	fset := token.NewFileSet()
+	for _, fn := range files {
+		if fn == "paths_test.go" {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, fn, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", fn, perr)
+		}
+		// [lo,hi) ranges of the sanctioned helper bodies; a marker literal is allowed only inside one.
+		type span struct{ lo, hi token.Pos }
+		var allow []span
+		for _, d := range f.Decls {
+			if fd, ok := d.(*ast.FuncDecl); ok && allowed[fd.Name.Name] && fd.Body != nil {
+				allow = append(allow, span{fd.Body.Pos(), fd.Body.End()})
+			}
+		}
+		inAllowed := func(p token.Pos) bool {
+			for _, s := range allow {
+				if p >= s.lo && p < s.hi {
+					return true
+				}
+			}
+			return false
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING && strings.Contains(lit.Value, marker) && !inAllowed(lit.Pos()) {
+				t.Errorf("%s: raw ruler path literal %s at %s is outside rulesGroupPath/rulesNamespacePath; use the helpers", fn, lit.Value, fset.Position(lit.Pos()))
+			}
+			return true
+		})
+	}
+}
+
+func TestBuildRuleGroupID(t *testing.T) {
+	if got := buildRuleGroupID("tenant-1", "ns a", "grp%x"); got != "tenant-1/ns%20a/grp%25x" {
+		t.Errorf("buildRuleGroupID(3-part) = %q, want %q", got, "tenant-1/ns%20a/grp%25x")
+	}
+	if got := buildRuleGroupID("", defaultNamespace, "my group"); got != "default/my%20group" {
+		t.Errorf("buildRuleGroupID(2-part) = %q, want %q", got, "default/my%20group")
+	}
+}

--- a/mimir/resource_mimir_rule_group_alerting.go
+++ b/mimir/resource_mimir_rule_group_alerting.go
@@ -23,17 +23,19 @@ func resourcemimirRuleGroupAlerting() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			orgIDKey: {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Description: orgIDDescription,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Description:  orgIDDescription,
+				ValidateFunc: validateOrgID,
 			},
 			namespaceKey: {
-				Type:        schema.TypeString,
-				Description: "Alerting Rule group namespace",
-				ForceNew:    true,
-				Optional:    true,
-				Default:     "default",
+				Type:         schema.TypeString,
+				Description:  "Alerting Rule group namespace",
+				ForceNew:     true,
+				Optional:     true,
+				Default:      defaultNamespace,
+				ValidateFunc: validateNamespace,
 			},
 			"name": {
 				Type:         schema.TypeString,
@@ -123,7 +125,7 @@ func resourcemimirRuleGroupAlertingCreate(ctx context.Context, d *schema.Resourc
 	if !overwriteRuleGroupConfig {
 		ruleGroupConfigExists := true
 
-		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+		path := rulesGroupPath(namespace, name)
 		headers := make(map[string]string)
 		if orgID != "" {
 			headers["X-Scope-OrgID"] = orgID
@@ -159,18 +161,14 @@ func resourcemimirRuleGroupAlertingCreate(ctx context.Context, d *schema.Resourc
 		headers["X-Scope-OrgID"] = orgID
 	}
 
-	path := fmt.Sprintf("/config/v1/rules/%s", namespace)
+	path := rulesNamespacePath(namespace)
 	_, err := client.sendRequest("ruler", "POST", path, string(data), headers)
 	baseMsg := fmt.Sprintf("Cannot create alerting rule group '%s' (namespace: %s) -", name, namespace)
 	err = handleHTTPError(err, baseMsg)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if orgID != "" {
-		d.SetId(fmt.Sprintf("%s/%s/%s", orgID, namespace, name))
-	} else {
-		d.SetId(fmt.Sprintf("%s/%s", namespace, name))
-	}
+	d.SetId(buildRuleGroupID(orgID, namespace, name))
 
 	// Retry read as mimir api could return a 404 status code caused by the event change notification propagation.
 	// Add delay of <ruleGroupReadDelayAfterChange> * time.Second) between each retry with a <ruleGroupReadRetryAfterChange> max retries.
@@ -189,21 +187,11 @@ func resourcemimirRuleGroupAlertingCreate(ctx context.Context, d *schema.Resourc
 func resourcemimirRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	// use id as read is also called by import
-	idArr := strings.Split(d.Id(), "/")
-
-	var name, namespace, orgID string
-
-	switch len(idArr) {
-	case 2:
-		namespace = idArr[0]
-		name = idArr[1]
-	case 3:
-		orgID = idArr[0]
-		namespace = idArr[1]
-		name = idArr[2]
-	default:
-		return diag.FromErr(fmt.Errorf("invalid id format: expected 'namespace/name' or 'org_id/namespace/name', got '%s'", d.Id()))
+	// use id as read is also called by import; parseRuleGroupID unescapes and re-validates
+	// every segment so an import/legacy '/'-in-namespace cannot fabricate an X-Scope-OrgID.
+	orgID, namespace, name, err := parseRuleGroupID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	jobraw, err := ruleGroupAlertingRead(meta, name, namespace, orgID)
@@ -285,7 +273,7 @@ func resourcemimirRuleGroupAlertingUpdate(ctx context.Context, d *schema.Resourc
 			headers["X-Scope-OrgID"] = orgID
 		}
 
-		path := fmt.Sprintf("/config/v1/rules/%s", namespace)
+		path := rulesNamespacePath(namespace)
 		_, err := client.sendRequest("ruler", "POST", path, string(data), headers)
 		baseMsg := fmt.Sprintf("Cannot update alerting rule group '%s' (namespace: %s) -", name, namespace)
 
@@ -309,7 +297,7 @@ func resourcemimirRuleGroupAlertingDelete(ctx context.Context, d *schema.Resourc
 	if orgID != "" {
 		headers["X-Scope-OrgID"] = orgID
 	}
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	path := rulesGroupPath(namespace, name)
 	_, err := client.sendRequest("ruler", "DELETE", path, "", headers)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(
@@ -341,7 +329,7 @@ func ruleGroupAlertingRead(meta interface{}, name, namespace, orgID string) (str
 		headers["X-Scope-OrgID"] = orgID
 	}
 	client := meta.(*apiClient)
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	path := rulesGroupPath(namespace, name)
 	jobraw, err := client.sendRequest("ruler", "GET", path, "", headers)
 	baseMsg := fmt.Sprintf("Cannot read alerting rule group '%s' (namespace: %s) -", name, namespace)
 	return jobraw, handleHTTPError(err, baseMsg)
@@ -426,9 +414,9 @@ func flattenAlertingRules(v []alertingRule) []map[string]interface{} {
 func validateAlertingRuleName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
-	if !alertNameRegexp.MatchString(value) {
+	if !validRuleName(value) {
 		errors = append(errors, fmt.Errorf(
-			"\"%s\": Invalid Alerting Rule Name %q. Must match the regex %s", k, value, alertNameRegexp))
+			"\"%s\": Invalid Alerting Rule Name %q: must be non-empty, not whitespace-only, not \".\" or \"..\", and contain no control characters or '/'", k, value))
 	}
 
 	return

--- a/mimir/resource_mimir_rule_group_alerting_test.go
+++ b/mimir/resource_mimir_rule_group_alerting_test.go
@@ -45,7 +45,7 @@ func TestAccResourceRuleGroupAlerting_expectValidationError(t *testing.T) {
 
 const testAccResourceRuleGroupAlerting_expectNameValidationError = `
     resource "mimir_rule_group_alerting" "alert_1" {
-        name = "alert-@error" 
+        name = "invalid/name"
         namespace = "namespace_1"
         rule {
             alert = "test1_alert"
@@ -59,7 +59,7 @@ const testAccResourceRuleGroupAlerting_expectRuleNameValidationError = `
         name = "alert_1"
         namespace = "namespace_1"
         rule {
-            alert = "test1 alert"
+            alert = "invalid/alert"
             expr   = "test1_metric"
         }
     }

--- a/mimir/resource_mimir_rule_group_recording.go
+++ b/mimir/resource_mimir_rule_group_recording.go
@@ -23,17 +23,19 @@ func resourcemimirRuleGroupRecording() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			orgIDKey: {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Description: orgIDDescription,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Description:  orgIDDescription,
+				ValidateFunc: validateOrgID,
 			},
 			namespaceKey: {
-				Type:        schema.TypeString,
-				Description: "Recording Rule group namespace",
-				ForceNew:    true,
-				Optional:    true,
-				Default:     "default",
+				Type:         schema.TypeString,
+				Description:  "Recording Rule group namespace",
+				ForceNew:     true,
+				Optional:     true,
+				Default:      defaultNamespace,
+				ValidateFunc: validateNamespace,
 			},
 			"name": {
 				Type:         schema.TypeString,
@@ -117,7 +119,7 @@ func resourcemimirRuleGroupRecordingCreate(ctx context.Context, d *schema.Resour
 	if !overwriteRuleGroupConfig {
 		ruleGroupConfigExists := true
 
-		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+		path := rulesGroupPath(namespace, name)
 		headers := make(map[string]string)
 		if orgID != "" {
 			headers["X-Scope-OrgID"] = orgID
@@ -160,18 +162,14 @@ func resourcemimirRuleGroupRecordingCreate(ctx context.Context, d *schema.Resour
 		headers["X-Scope-OrgID"] = orgID
 	}
 
-	path := fmt.Sprintf("/config/v1/rules/%s", namespace)
+	path := rulesNamespacePath(namespace)
 	_, err := client.sendRequest("ruler", "POST", path, string(data), headers)
 	baseMsg := fmt.Sprintf("Cannot create recording rule group '%s' (namespace: %s) -", name, namespace)
 	err = handleHTTPError(err, baseMsg)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if orgID != "" {
-		d.SetId(fmt.Sprintf("%s/%s/%s", orgID, namespace, name))
-	} else {
-		d.SetId(fmt.Sprintf("%s/%s", namespace, name))
-	}
+	d.SetId(buildRuleGroupID(orgID, namespace, name))
 
 	// Retry read as mimir api could return a 404 status code caused by the event change notification propagation.
 	// Add delay of <ruleGroupReadDelayAfterChange> * time.Second) between each retry with a <ruleGroupReadRetryAfterChange> max retries.
@@ -190,21 +188,11 @@ func resourcemimirRuleGroupRecordingCreate(ctx context.Context, d *schema.Resour
 func resourcemimirRuleGroupRecordingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	// use id as read is also called by import
-	idArr := strings.Split(d.Id(), "/")
-
-	var name, namespace, orgID string
-
-	switch len(idArr) {
-	case 2:
-		namespace = idArr[0]
-		name = idArr[1]
-	case 3:
-		orgID = idArr[0]
-		namespace = idArr[1]
-		name = idArr[2]
-	default:
-		return diag.FromErr(fmt.Errorf("invalid id format: expected 'namespace/name' or 'org_id/namespace/name', got '%s'", d.Id()))
+	// use id as read is also called by import; parseRuleGroupID unescapes and re-validates
+	// every segment so an import/legacy '/'-in-namespace cannot fabricate an X-Scope-OrgID.
+	orgID, namespace, name, err := parseRuleGroupID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	jobraw, err := ruleGroupRecordingRead(meta, name, namespace, orgID)
@@ -301,7 +289,7 @@ func resourcemimirRuleGroupRecordingUpdate(ctx context.Context, d *schema.Resour
 			headers["X-Scope-OrgID"] = orgID
 		}
 
-		path := fmt.Sprintf("/config/v1/rules/%s", namespace)
+		path := rulesNamespacePath(namespace)
 		_, err := client.sendRequest("ruler", "POST", path, string(data), headers)
 		baseMsg := fmt.Sprintf("Cannot update recording rule group '%s' (namespace: %s)  -", name, namespace)
 		err = handleHTTPError(err, baseMsg)
@@ -324,7 +312,7 @@ func resourcemimirRuleGroupRecordingDelete(ctx context.Context, d *schema.Resour
 	if orgID != "" {
 		headers["X-Scope-OrgID"] = orgID
 	}
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	path := rulesGroupPath(namespace, name)
 	_, err := client.sendRequest("ruler", "DELETE", path, "", headers)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(
@@ -356,7 +344,7 @@ func ruleGroupRecordingRead(meta interface{}, name, namespace, orgID string) (st
 		headers["X-Scope-OrgID"] = orgID
 	}
 	client := meta.(*apiClient)
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+	path := rulesGroupPath(namespace, name)
 	jobraw, err := client.sendRequest("ruler", "GET", path, "", headers)
 	baseMsg := fmt.Sprintf("Cannot read recording rule group '%s' (namespace: %s) -", name, namespace)
 	return jobraw, handleHTTPError(err, baseMsg)

--- a/mimir/resource_mimir_rule_group_recording_test.go
+++ b/mimir/resource_mimir_rule_group_recording_test.go
@@ -37,7 +37,7 @@ func TestAccResourceRuleGroupRecording_expectValidationError(t *testing.T) {
 
 const testAccResourceRuleGroupRecording_expectNameValidationError = `
 	resource "mimir_rule_group_recording" "record_1" {
-		name = "record_1-@error"
+		name = "invalid/name"
 		namespace = "namespace_1"
 		rule {
 			record = "test1_info"

--- a/mimir/resource_mimir_rules.go
+++ b/mimir/resource_mimir_rules.go
@@ -72,14 +72,15 @@ func resourceMimirRules() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				Description:  "The namespace for the rule groups",
-				ValidateFunc: validation.StringLenBetween(1, 100),
+				ValidateFunc: validation.All(validation.StringLenBetween(1, 100), validateNamespace),
 			},
 
 			orgIDKey: {
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Optional:    true,
-				Description: orgIDDescription,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Description:  orgIDDescription,
+				ValidateFunc: validateOrgID,
 			},
 
 			// Content input methods (mutually exclusive)
@@ -312,8 +313,8 @@ func validateRuleGroupsContent(ruleGroups RuleGroups) error {
 			return fmt.Errorf("group %d: name is required", i)
 		}
 
-		if !groupRuleNameRegexp.MatchString(group.Name) {
-			return fmt.Errorf("invalid Group Rule Name %s. Must match the regex %s", group.Name, groupRuleNameRegexp)
+		if !validRuleName(group.Name) {
+			return fmt.Errorf("invalid Group Rule Name %q: must be non-empty, not whitespace-only, not \".\" or \"..\", and contain no control characters or '/'", group.Name)
 		}
 
 		if groupNames[group.Name] {
@@ -364,8 +365,8 @@ func validateRule(rule Rule, groupIndex, ruleIndex int, groupName string) error 
 	// Alerting rule specific validation
 	if hasAlert {
 		// Validate alert name
-		if !alertNameRegexp.MatchString(rule.Alert) {
-			return fmt.Errorf("group %d (%s), rule %d: invalid alert name '%s'. Must match the regex %s", groupIndex, groupName, ruleIndex, rule.Alert, alertNameRegexp)
+		if !validRuleName(rule.Alert) {
+			return fmt.Errorf("group %d (%s), rule %d: invalid alert name %q: must be non-empty, not whitespace-only, not \".\" or \"..\", and contain no control characters or '/'", groupIndex, groupName, ruleIndex, rule.Alert)
 		}
 
 		// Validate 'for' duration if specified
@@ -490,7 +491,7 @@ func resourceMimirRulesRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	var existingGroups []string
 	for _, groupName := range managedGroups {
-		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, groupName)
+		path := rulesGroupPath(namespace, groupName)
 		_, err := client.sendRequest("ruler", "GET", path, "", headers)
 		if err != nil {
 			if strings.Contains(err.Error(), "does not exist") {
@@ -628,6 +629,16 @@ func resourceMimirRulesImport(ctx context.Context, d *schema.ResourceData, m int
 
 	orgID := parts[0]
 	namespace := parts[1]
+
+	// ValidateFunc does not run on values an importer sets via d.Set, so re-validate here:
+	// reject control chars / '/' / dot-segments before they reach the ruler path or the
+	// X-Scope-OrgID header. (The strict 2-part split already blocks a '/'-fabrication.)
+	if !validOrgID(orgID) {
+		return nil, fmt.Errorf("import ID %q: org_id must contain no control characters", d.Id())
+	}
+	if !validNamespace(namespace) {
+		return nil, fmt.Errorf("import ID %q: namespace %q must not be \".\"/\"..\" and must contain no control characters or '/'", d.Id(), namespace)
+	}
 
 	d.Set(orgIDKey, orgID)
 	d.Set(namespaceKey, namespace)
@@ -776,7 +787,7 @@ func createRuleGroup(client *apiClient, namespace, orgID string, group RuleGroup
 		return fmt.Errorf("failed to marshal rule group to YAML: %w", err)
 	}
 
-	path := fmt.Sprintf("/config/v1/rules/%s", namespace)
+	path := rulesNamespacePath(namespace)
 	_, err = client.sendRequest("ruler", "POST", path, string(yamlData), headers)
 	return err
 }
@@ -787,7 +798,7 @@ func deleteRuleGroup(client *apiClient, namespace, orgID, groupName string) erro
 		headers["X-Scope-OrgID"] = orgID
 	}
 
-	path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, groupName)
+	path := rulesGroupPath(namespace, groupName)
 	_, err := client.sendRequest("ruler", "DELETE", path, "", headers)
 	if err != nil && strings.Contains(err.Error(), "response code '404'") {
 		// Group already doesn't exist, consider this success

--- a/mimir/roundtrip_acc_test.go
+++ b/mimir/roundtrip_acc_test.go
@@ -310,3 +310,44 @@ resource "mimir_rule_group_recording" "rt" {
   }
 }
 `
+
+// Pins the upstream rulefmt scope of the braces "common-mistake check" (prometheus#15851):
+// it applies to RECORD names only, so alert and group names containing braces are valid and
+// must round-trip. (Record names with braces are rejected by this provider's own strict
+// metric-name validation, matching the server.)
+func TestAccResourceRuleGroupAlerting_BracesNameRoundTrip(t *testing.T) {
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoundTrip_bracesName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.braces", "Braces {Group}", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.braces", "name", "Braces {Group}"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.braces", "rule.0.alert", `alert{env="prod"}`),
+				),
+			},
+			{
+				Config:   testAccRoundTrip_bracesName,
+				PlanOnly: true, // re-apply is a clean no-op
+			},
+		},
+	})
+}
+
+const testAccRoundTrip_bracesName = `
+resource "mimir_rule_group_alerting" "braces" {
+  name      = "Braces {Group}"
+  namespace = "namespace_braces"
+  rule {
+    alert = "alert{env=\"prod\"}"
+    expr  = "up"
+  }
+}
+`

--- a/mimir/roundtrip_acc_test.go
+++ b/mimir/roundtrip_acc_test.go
@@ -1,0 +1,312 @@
+package mimir
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCountRuleGroups(t *testing.T) {
+	cases := []struct {
+		body    string
+		want    int
+		wantErr bool
+	}{
+		{"", 0, false},
+		{"null\n", 0, false},
+		{"[]\n", 0, false},
+		{"{}\n", 0, false},
+		{"namespace_sc:\n- name: g1\n", 1, false},
+		{"namespace_sc:\n- name: g1\n- name: g2\n", 2, false},
+		{"- name: g1\n", 1, false}, // flat list
+		{"not-a-collection", 0, true},
+	}
+	for _, c := range cases {
+		got, err := countRuleGroups(c.body)
+		if (err != nil) != c.wantErr {
+			t.Errorf("countRuleGroups(%q) err=%v, wantErr=%v", c.body, err, c.wantErr)
+		}
+		if err == nil && got != c.want {
+			t.Errorf("countRuleGroups(%q) = %d, want %d", c.body, got, c.want)
+		}
+	}
+}
+
+// countRuleGroups decodes a ruler namespace-listing response and returns the group count. It
+// accepts both observed shapes — a namespace-keyed map ({<ns>: [{name: ...}]}) and a flat list
+// ([{name: ...}]) — and returns 0 for the legitimately-empty forms ("", "null", "[]", "{}").
+// It errors ONLY when the body decodes as neither (a genuine shape/parse mismatch), so a real
+// empty namespace never false-fails. The exact live shape is confirmed in CI (2.17.10 + 3.0.6);
+// TestCountRuleGroups pins this decode logic without a network.
+func countRuleGroups(body string) (int, error) {
+	type group struct {
+		Name string `yaml:"name"`
+	}
+	var byNamespace map[string][]group
+	if err := yaml.Unmarshal([]byte(body), &byNamespace); err == nil {
+		n := 0
+		for _, groups := range byNamespace {
+			n += len(groups)
+		}
+		return n, nil
+	}
+	var flat []group
+	if err := yaml.Unmarshal([]byte(body), &flat); err == nil {
+		return len(flat), nil
+	}
+	return 0, fmt.Errorf("could not decode ruler namespace listing as map or list: %q", body)
+}
+
+// testAccCheckMimirNamespaceGroupCount lists a namespace via the ruler API and asserts the
+// number of groups. Terraform state/ID stability alone cannot prove the backend has no orphan
+// at a mis-escaped path, so this out-of-band count guards the escaping/update paths.
+func testAccCheckMimirNamespaceGroupCount(namespace string, want int, client *apiClient) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		body, err := client.sendRequest("ruler", "GET", rulesNamespacePath(namespace), "", map[string]string{})
+		if err != nil {
+			return fmt.Errorf("listing namespace %q: %w", namespace, err)
+		}
+		got, err := countRuleGroups(body)
+		if err != nil {
+			return fmt.Errorf("namespace %q: %w", namespace, err)
+		}
+		if got != want {
+			return fmt.Errorf("namespace %q group count = %d, want %d", namespace, got, want)
+		}
+		return nil
+	}
+}
+
+// AC4 regression guard: a space-containing name is the one class that round-trips today by
+// luck; prove the escaping change did not break it, through apply -> read -> destroy.
+func TestAccResourceRuleGroupAlerting_SpecialNameRoundTrip(t *testing.T) {
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoundTrip_specialName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.special", "Harvest Rules", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.special", "name", "Harvest Rules"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.special", "rule.0.alert", "LUN Destroyed"),
+				),
+			},
+			{
+				Config:   testAccRoundTrip_specialName,
+				PlanOnly: true, // re-apply is a clean no-op
+			},
+		},
+	})
+}
+
+// AC4 new class: %/# names do not round-trip today. Full lifecycle incl an in-place update,
+// with an out-of-band count proving the update targets the existing group (no orphan).
+func TestAccResourceRuleGroupAlerting_SpecialCharRoundTrip(t *testing.T) {
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoundTrip_specialChar,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.sc", "a%b#c", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.sc", "name", "a%b#c"),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.sc", "rule.0.alert", "alert %x"),
+					testAccCheckMimirNamespaceGroupCount("namespace_sc", 1, client),
+				),
+			},
+			{
+				Config: testAccRoundTrip_specialCharUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.sc", "a%b#c", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.sc", "rule.0.expr", "up > 1"),
+					// update must target the existing group, not orphan/duplicate it
+					testAccCheckMimirNamespaceGroupCount("namespace_sc", 1, client),
+				),
+			},
+		},
+	})
+}
+
+// AC5: a namespace with a space round-trips (accepted, escaped); a namespace with '/' is
+// rejected at plan time (so the cross-tenant ID-misparse cannot occur).
+func TestAccResourceRuleGroupAlerting_NamespaceRoundTrip(t *testing.T) {
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRoundTrip_nsSlash,
+				ExpectError: regexp.MustCompile("Invalid Namespace"),
+			},
+			{
+				Config: testAccRoundTrip_nsSpace,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.nss", "grp", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_alerting.nss", "namespace", "team space"),
+				),
+			},
+		},
+	})
+}
+
+// AC5 / ID-hardening: the escaped-ID scheme round-trips through import for ordinary names.
+func TestAccResourceRuleGroupAlerting_ImportRoundTrip(t *testing.T) {
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoundTrip_specialName,
+				Check:  testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.special", "Harvest Rules", client),
+			},
+			{
+				ResourceName:      "mimir_rule_group_alerting.special",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// AC5 / ID-hardening at the import wiring: a crafted import ID with a '/'-in-namespace (as
+// %2F) is rejected through the real Importer/Read path, not only at the parseRuleGroupID
+// unit level — so a regression in the Importer wiring would be caught.
+func TestAccResourceRuleGroupAlerting_ImportRejectRoundTrip(t *testing.T) {
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoundTrip_specialName,
+				Check:  testAccCheckMimirRuleGroupExists("mimir_rule_group_alerting.special", "Harvest Rules", client),
+			},
+			{
+				ResourceName:  "mimir_rule_group_alerting.special",
+				ImportState:   true,
+				ImportStateId: "team%2Fevil/grp", // '/'-in-namespace (as %2F) must be rejected
+				ExpectError:   regexp.MustCompile("namespace .* must not"),
+			},
+		},
+	})
+}
+
+// AC1/AC4 for the typed recording resource: a special group name with an ordinary (strict)
+// record name.
+func TestAccResourceRuleGroupRecording_SpecialNameRoundTrip(t *testing.T) {
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMimirRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoundTrip_recordingSpecial,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMimirRuleGroupExists("mimir_rule_group_recording.rt", "Rec Group %x", client),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.rt", "name", "Rec Group %x"),
+					resource.TestCheckResourceAttr("mimir_rule_group_recording.rt", "rule.0.record", "valid_record"),
+				),
+			},
+		},
+	})
+}
+
+const testAccRoundTrip_specialName = `
+resource "mimir_rule_group_alerting" "special" {
+  name      = "Harvest Rules"
+  namespace = "namespace_special"
+  rule {
+    alert = "LUN Destroyed"
+    expr  = "up"
+  }
+}
+`
+
+const testAccRoundTrip_specialChar = `
+resource "mimir_rule_group_alerting" "sc" {
+  name      = "a%b#c"
+  namespace = "namespace_sc"
+  rule {
+    alert = "alert %x"
+    expr  = "up"
+  }
+}
+`
+
+const testAccRoundTrip_specialCharUpdate = `
+resource "mimir_rule_group_alerting" "sc" {
+  name      = "a%b#c"
+  namespace = "namespace_sc"
+  rule {
+    alert = "alert %x"
+    expr  = "up > 1"
+  }
+}
+`
+
+const testAccRoundTrip_nsSpace = `
+resource "mimir_rule_group_alerting" "nss" {
+  name      = "grp"
+  namespace = "team space"
+  rule {
+    alert = "a"
+    expr  = "up"
+  }
+}
+`
+
+const testAccRoundTrip_nsSlash = `
+resource "mimir_rule_group_alerting" "nsslash" {
+  name      = "grp"
+  namespace = "team/space"
+  rule {
+    alert = "a"
+    expr  = "up"
+  }
+}
+`
+
+const testAccRoundTrip_recordingSpecial = `
+resource "mimir_rule_group_recording" "rt" {
+  name      = "Rec Group %x"
+  namespace = "namespace_rec"
+  rule {
+    record = "valid_record"
+    expr   = "up"
+  }
+}
+`

--- a/mimir/shared.go
+++ b/mimir/shared.go
@@ -2,9 +2,11 @@ package mimir
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/prometheus/common/model"
@@ -12,13 +14,122 @@ import (
 )
 
 var (
-	groupRuleNameRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-_.]*$`)
-	alertNameRegexp     = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-_.:]*$`)
-	labelNameRegexp     = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
-	metricNameRegexp    = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
-	validTime           = "^((([01][0-9])|(2[0-3])):[0-5][0-9])$|(^24:00$)"
-	validTimeRE         = regexp.MustCompile(validTime)
+	labelNameRegexp  = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+	metricNameRegexp = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+	validTime        = "^((([01][0-9])|(2[0-3])):[0-5][0-9])$|(^24:00$)"
+	validTimeRE      = regexp.MustCompile(validTime)
 )
+
+// hasControlChar reports whether s contains any Unicode control character (category Cc:
+// the ASCII C0 controls, DEL, and C1 controls such as NEL U+0085). Keeps control bytes out
+// of names, namespaces, and the X-Scope-OrgID header. unicode.IsControl is used because the
+// ASCII regex class [:cntrl:] would miss the C1 range.
+func hasControlChar(s string) bool {
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// validRuleName is the permissive validity guard for alert and rule-group names. It accepts
+// a name that is non-empty, not whitespace-only, not the "."/".." dot-segment, and free of
+// (Unicode) control characters and '/'. Dot-segments are rejected because routers and proxies
+// normalize them as path traversal, breaking the read/update/delete round-trip.
+func validRuleName(s string) bool {
+	if s == "." || s == ".." {
+		return false
+	}
+	return strings.TrimSpace(s) != "" && !strings.ContainsRune(s, '/') && !hasControlChar(s)
+}
+
+// validNamespace is the narrower namespace guard: reject '/', control characters, and the
+// "."/".." dot-segments; empty is allowed (the field defaults to "default"). Rejecting '/'
+// is a security requirement: a '/' in a namespace collides with the "/"-joined Terraform
+// resource ID and would fabricate an X-Scope-OrgID tenant, causing cross-tenant read/delete.
+func validNamespace(s string) bool {
+	if s == "." || s == ".." {
+		return false
+	}
+	return !strings.ContainsRune(s, '/') && !hasControlChar(s)
+}
+
+// validOrgID applies the same rule as validNamespace: reject '/', control characters, and
+// the "."/".." dot-segments (empty is allowed). org_id becomes the X-Scope-OrgID tenant and
+// is used by Mimir as a storage-path component, so a '/' or "."/".." is a cross-tenant
+// path-traversal/collision primitive — and a '/' would also break the "orgID/namespace/name"
+// Terraform ID. (Control chars are additionally rejected to prevent header injection.)
+func validOrgID(s string) bool {
+	if s == "." || s == ".." {
+		return false
+	}
+	return !strings.ContainsRune(s, '/') && !hasControlChar(s)
+}
+
+// rulesGroupPath builds a ruler-API path that addresses a rule group by name, with each
+// segment URL-path-escaped so a relaxed name (spaces, %, #, ?) survives read/delete instead
+// of mis-decoding. Escaping happens here, never inside sendRequest.
+func rulesGroupPath(namespace, name string) string {
+	return "/config/v1/rules/" + url.PathEscape(namespace) + "/" + url.PathEscape(name)
+}
+
+// rulesNamespacePath builds the namespace-only ruler-API path used by create/update (the
+// group name travels in the request body there), with the namespace segment escaped.
+func rulesNamespacePath(namespace string) string {
+	return "/config/v1/rules/" + url.PathEscape(namespace)
+}
+
+// buildRuleGroupID encodes the typed-resource Terraform ID with each segment URL-escaped,
+// so a delimiter-colliding character in a segment cannot shift the parse. An empty orgID
+// yields the 2-segment form.
+func buildRuleGroupID(orgID, namespace, name string) string {
+	if orgID != "" {
+		return url.PathEscape(orgID) + "/" + url.PathEscape(namespace) + "/" + url.PathEscape(name)
+	}
+	return url.PathEscape(namespace) + "/" + url.PathEscape(name)
+}
+
+// parseRuleGroupID splits and unescapes a typed-resource Terraform ID and re-validates every
+// segment. A raw '/' is always the delimiter, so a literal '/' inside a value can only appear
+// as %2F, which decodes and is then rejected by validNamespace — closing the terraform-import
+// and legacy-state cross-tenant vectors that schema ValidateFuncs never see. It rejects an ID
+// that PathUnescape cannot decode, or whose orgID/namespace/name fail their guards.
+func parseRuleGroupID(id string) (orgID, namespace, name string, err error) {
+	idArr := strings.Split(id, "/")
+	var raw [3]string // orgID, namespace, name
+	switch len(idArr) {
+	case 2:
+		raw = [3]string{"", idArr[0], idArr[1]}
+	case 3:
+		raw = [3]string{idArr[0], idArr[1], idArr[2]}
+	default:
+		return "", "", "", fmt.Errorf("invalid id format: expected 'namespace/name' or 'org_id/namespace/name', got %q", id)
+	}
+	var dec [3]string
+	for i, seg := range raw {
+		d, uerr := url.PathUnescape(seg)
+		if uerr != nil {
+			// Legacy IDs were stored unescaped, so a bare '%' (e.g. namespace "50% teams")
+			// is not valid percent-encoding. Fall back to the raw segment rather than
+			// hard-failing Read; the guards below still reject '/'/control/dot-segments,
+			// and rulesGroupPath re-escapes the value on the wire.
+			d = seg
+		}
+		dec[i] = d
+	}
+	orgID, namespace, name = dec[0], dec[1], dec[2]
+	if !validOrgID(orgID) {
+		return "", "", "", fmt.Errorf("invalid id %q: org_id must contain no control characters", id)
+	}
+	if !validNamespace(namespace) {
+		return "", "", "", fmt.Errorf("invalid id %q: namespace %q must not be \".\"/\"..\" and must contain no control characters or '/'", id, namespace)
+	}
+	if !validRuleName(name) {
+		return "", "", "", fmt.Errorf("invalid id %q: name %q must be non-empty, not whitespace-only, not \".\"/\"..\", and contain no control characters or '/'", id, name)
+	}
+	return orgID, namespace, name, nil
+}
 
 func handleHTTPError(err error, baseMsg string) error {
 	if err != nil {
@@ -51,9 +162,46 @@ func expandStringMap(v map[string]interface{}) map[string]string {
 func validateGroupRuleName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
-	if !groupRuleNameRegexp.MatchString(value) {
+	if !validRuleName(value) {
 		errors = append(errors, fmt.Errorf(
-			"\"%s\": Invalid Group Rule Name %q. Must match the regex %s", k, value, groupRuleNameRegexp))
+			"\"%s\": Invalid Group Rule Name %q: must be non-empty, not whitespace-only, not \".\" or \"..\", and contain no control characters or '/'", k, value))
+	}
+
+	return
+}
+
+// pctEncodedSeqRegexp matches a valid percent-encoding sequence (e.g. "%20"). Used only to
+// WARN: older provider versions interpolated the namespace raw into the ruler URL, so the
+// server percent-decoded it once (HCL "team%20a" silently addressed namespace "team a").
+// Values are now sent literally, matching mimirtool's behavior.
+var pctEncodedSeqRegexp = regexp.MustCompile(`%[0-9a-fA-F]{2}`)
+
+func validateNamespace(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if !validNamespace(value) {
+		errors = append(errors, fmt.Errorf(
+			"\"%s\": Invalid Namespace %q: must not be \".\" or \"..\" and must contain no control characters or '/'", k, value))
+		return
+	}
+
+	if pctEncodedSeqRegexp.MatchString(value) {
+		if decoded, err := url.PathUnescape(value); err == nil && decoded != value {
+			ws = append(ws, fmt.Sprintf(
+				"%q: namespace %q contains a percent-encoding sequence and is now sent literally (matching mimirtool); older provider versions let the server decode it once. If you meant %q, use that value instead — it addresses the same server-side namespace as before.",
+				k, value, decoded))
+		}
+	}
+
+	return
+}
+
+func validateOrgID(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if !validOrgID(value) {
+		errors = append(errors, fmt.Errorf(
+			"\"%s\": Invalid Org ID %q: must not be \".\"/\"..\" and must contain no control characters or '/'", k, value))
 	}
 
 	return

--- a/mimir/shared_test.go
+++ b/mimir/shared_test.go
@@ -50,7 +50,7 @@ func testAccCheckMimirRuleGroupHasLabel(n, group, key, val string, client *apiCl
 		if orgID != "" {
 			headers["X-Scope-OrgID"] = orgID
 		}
-		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, group)
+		path := rulesGroupPath(namespace, group)
 		body, err := client.sendRequest("ruler", "GET", path, "", headers)
 		if err != nil {
 			return err
@@ -101,7 +101,7 @@ func testAccCheckMimirRuleGroupExists(n string, name string, client *apiClient) 
 		if orgID != "" {
 			headers["X-Scope-OrgID"] = orgID
 		}
-		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+		path := rulesGroupPath(namespace, name)
 		_, err := client.sendRequest("ruler", "GET", path, "", headers)
 		if err != nil {
 			return err
@@ -134,7 +134,7 @@ func testAccCheckMimirNamespaceExists(n string, name string, client *apiClient) 
 		if orgID != "" {
 			headers["X-Scope-OrgID"] = orgID
 		}
-		path := fmt.Sprintf("/config/v1/rules/%s", namespace)
+		path := rulesNamespacePath(namespace)
 		_, err := client.sendRequest("ruler", "GET", path, "", headers)
 		if err != nil {
 			return err
@@ -163,7 +163,7 @@ func testAccCheckMimirRuleGroupGone(n string, groupName string, client *apiClien
 		if orgID != "" {
 			headers["X-Scope-OrgID"] = orgID
 		}
-		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, groupName)
+		path := rulesGroupPath(namespace, groupName)
 		_, err := client.sendRequest("ruler", "GET", path, "", headers)
 		if err == nil {
 			return fmt.Errorf("rule group %q in namespace %q still exists in Mimir; expected 404", groupName, namespace)
@@ -194,7 +194,7 @@ func testAccCheckMimirRuleGroupDestroy(s *terraform.State) error {
 		if orgID != "" {
 			headers["X-Scope-OrgID"] = orgID
 		}
-		path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, name)
+		path := rulesGroupPath(namespace, name)
 		_, err := client.sendRequest("ruler", "GET", path, "", headers)
 
 		// If the error is equivalent to 404 not found, the widget is destroyed.
@@ -232,7 +232,7 @@ func testAccCheckMimirRuleDestroy(s *terraform.State) error {
 		for i := 0; i < managedGroupsCount; i++ {
 			groupName := rs.Primary.Attributes[fmt.Sprintf("managed_groups.%d", i)]
 
-			path := fmt.Sprintf("/config/v1/rules/%s/%s", namespace, groupName)
+			path := rulesGroupPath(namespace, groupName)
 			_, err := client.sendRequest("ruler", "GET", path, "", headers)
 
 			// If the error is equivalent to 404 not found, the group is destroyed.


### PR DESCRIPTION
This PR makes the provider accept the rule-group and alert names that Grafana (and other tooling) actually produces, and fixes how those names travel through the ruler API so they survive the full lifecycle.

## The problem

We manage alerts that are **generated by other software** (Grafana exports) and deployed through a CD pipeline. Those tools don't follow the provider's naming regexes, so perfectly valid rules fail to deploy:

```
Error: invalid alert name 'LUN Destroyed'. Must match the regex ^[a-zA-Z][a-zA-Z0-9-_.:]*$
Error: invalid Group Rule Name Harvest Rules. Must match the regex ^[a-zA-Z][a-zA-Z0-9-_.]*$
```

The backend is much more permissive than these regexes (per Prometheus `rulefmt`, a group name only needs to be non-empty; an alert name is a label value). Renaming every export by hand defeats the point of managing them as code, since we want to keep pulling updated exports.

## What this PR changes

**1. Name validation matches reality.** Alert and rule-group names now accept what Grafana produces (spaces, quotes, braces, unicode, `%`, `#`, …). Still rejected: empty/whitespace-only names, control characters, `/`, and `.`/`..` — things that cannot work in a URL path or the Terraform resource ID. Metric names, recording-rule (`record`) names, and label/annotation names keep their strict Prometheus rules — those regexes are correct for those fields.

**2. Ruler API paths are percent-escaped — the same thing mimirtool does.** Previously names were interpolated raw into the URL (`fmt.Sprintf("/config/v1/rules/%s/%s", ns, name)`). That only appeared to work for simple names: a `%` crashed the provider, a `#` silently truncated the path so the provider talked to the *wrong namespace*, and the Grafana ecosystem's own client escapes these paths — see `url.PathEscape(namespace)` / `url.PathEscape(groupName)` in [mimirtool's rules client](https://github.com/grafana/mimir/blob/main/pkg/mimirtool/client/rules.go). This PR uses the exact same escaping (shared `rulesGroupPath`/`rulesNamespacePath` helpers), so the provider now addresses the server identically to the official tooling. An AST-based test fails the build if a raw ruler path ever reappears.

**3. A cross-tenant bug is closed.** The typed resources rebuild their state from the Terraform ID by splitting on `/`. Since namespaces were never validated, a namespace containing `/` would shift that split and fabricate an `X-Scope-OrgID` — silently reading/deleting **another tenant's** rules. Namespaces and `org_id` are now validated (no `/`, control chars, or `.`/`..`), and the ID parse re-validates every segment on read and import, so this can't happen through config, `terraform import`, or legacy state.

## Compatibility

* **Any config the old provider accepted behaves identically.** The old name regexes were strict, so no existing name contains a special character; for namespaces, every previously-valid value produces byte-identical requests (verified against a recording server).
* The only inputs that behave differently are ones that were already broken: a `%` in a namespace **crashed** the provider, and `#`/`?` silently truncated the path (the provider talked to the wrong namespace). These now work and address the literal name — same semantics as mimirtool.
* One edge case gets a **plan-time warning** instead of a silent change: a namespace containing a valid percent-encoding sequence (e.g. `team%20a`), which the old code let the server decode to `team a`. The warning explains that the value is now sent literally and that writing the decoded form addresses the same server-side namespace as before. Happy to switch this to a hard error (or drop it) if you prefer a different compatibility stance.
* Validation error messages were reworded to state the rule instead of printing a regex; the `Invalid Group Rule Name` / `Invalid Alerting Rule Name` prefixes are unchanged so log matching keeps working.

## Testing

* Unit tests for the validators (accept/reject tables at every entry point), the path escaping, the ID round-trip incl. hostile import IDs, the importer guards, and the schema wiring; suite is green with `-race`.
* Acceptance tests (both CI legs, Mimir 2.17.10 + 3.0.6): full lifecycle — apply → read → no-op re-plan → in-place update → destroy — for names with spaces and `%`/`#` (with an out-of-band check that no orphan group is left behind), namespace policy (space works, `/` rejected), and import round-trip plus rejection of a crafted `%2F` import ID.
